### PR TITLE
WIP: Fixes issue where lost-move would not retain local gutter

### DIFF
--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -44,14 +44,13 @@ describe('lost-move', function() {
   });
   it('supports retaining gutter set by lost-column', function() {
     check(
-      'a { lost-column: 1/3 0 0} \m a { lost-move: 1/3}',
-      'a { width: calc(99.999999% * 1/3)}\n' +
+      'a { lost-column: 1/3 0 0} \n' +
+      'a { lost-move: 1/3}',
+      'a { width: calc(99.999999% * 1/3); position: relative; left: calc(99.999999% * 1/3)}\n' +
       'a:nth-child(n) { float: left; margin-right: 0; clear: none}\n' +
       'a:last-child { margin-right: 0}\n' +
       'a:nth-child(0n) { margin-right: 0}\n' +
-      'a:nth-child(0n + 1) { clear: left}\n' +
-      'a { position: relative; left: calc(99.99% * 1/3)' +
-      ' + 30px); }'
+      'a:nth-child(0n + 1) { clear: left}'
     );
   });
 });

--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -42,4 +42,16 @@ describe('lost-move', function() {
       ' + 60px); }'
     );
   });
+  it('supports retaining gutter set by lost-column', function() {
+    check(
+      'a { lost-column: 1/3 0 0} \m a { lost-move: 1/3}',
+      'a { width: calc(99.999999% * 1/3)}\n' +
+      'a:nth-child(n) { float: left; margin-right: 0; clear: none}\n' +
+      'a:last-child { margin-right: 0}\n' +
+      'a:nth-child(0n) { margin-right: 0}\n' +
+      'a:nth-child(0n + 1) { clear: left}\n' +
+      'a { position: relative; left: calc(99.99% * 1/3)' +
+      ' + 30px); }'
+    );
+  });
 });


### PR DESCRIPTION
From #195 

``` css
a {
  lost-column: 2/3 0 0 no-flex;
  lost-move: 1/3;
}
```

The `lost-move` rule overrides the `0` gutter from `lost-column`. This is addressed with this PR
