### PR TITLE
Adding space-between and space-around alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ section {
 #### lost-align
 Align nested elements. Apply this to a parent container.
 
-- `reset|horizontal|vertical|top-left|top-center|top|top-right|middle-left|left|middle-center|center|middle-right|right|bottom-left|bottom-center|bottom|bottom-right` - The position the nested element takes relative to the containing element.
+- `reset|horizontal|vertical|top-left|top-center|top|top-right|top-between|top-around||middle-left|left|middle-center|center|middle-right|right|middle-between|between|middle-around|around|bottom-left|bottom-center|bottom|bottom-right|bottom-between|bottom-around` - The position the nested element takes relative to the containing element.
 - `flex|no-flex` - Determines whether this element should use Flexbox or not.
 
 ```css

--- a/lib/lost-align.js
+++ b/lib/lost-align.js
@@ -43,10 +43,10 @@ module.exports = function lostAlignDecl(css, settings) {
         });
 
         newBlock(
-          decl,
-          ' > *',
-          ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-          ['static', 'auto', 'auto', 'auto', 'auto', 'translate(0, 0)']
+            decl,
+            ' > *',
+            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+            ['static', 'auto', 'auto', 'auto', 'auto', 'translate(0, 0)']
         );
       } else {
         decl.cloneBefore({
@@ -56,86 +56,87 @@ module.exports = function lostAlignDecl(css, settings) {
 
         if (lostAlign == 'horizontal') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', 'auto', 'auto', 'auto', '50%', 'translate(-50%, 0)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', 'auto', 'auto', 'auto', '50%', 'translate(-50%, 0)']
           );
         } else if (lostAlign == 'vertical') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', '50%', 'auto', 'auto', 'auto', 'translate(0, -50%)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', '50%', 'auto', 'auto', 'auto', 'translate(0, -50%)']
           );
         } else if (lostAlign == 'top-left') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', '0', 'auto', 'auto', '0', 'translate(0, 0)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', '0', 'auto', 'auto', '0', 'translate(0, 0)']
           );
         } else if (lostAlign == 'top-center' || lostAlign == 'top') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', '0', 'auto', 'auto', '50%', 'translate(-50%, 0)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', '0', 'auto', 'auto', '50%', 'translate(-50%, 0)']
           );
         } else if (lostAlign == 'top-right') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', '0', '0', 'auto', 'auto', 'translate(0, 0)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', '0', '0', 'auto', 'auto', 'translate(0, 0)']
           );
         } else if (lostAlign == 'middle-left' || lostAlign == 'left') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', '50%', 'auto', 'auto', '0', 'translate(0, -50%)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', '50%', 'auto', 'auto', '0', 'translate(0, -50%)']
           );
         } else if (lostAlign == 'middle-center' || lostAlign == 'center') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', '50%', 'auto', 'auto', '50%', 'translate(-50%, -50%)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', '50%', 'auto', 'auto', '50%', 'translate(-50%, -50%)']
           );
         } else if (lostAlign == 'middle-right' || lostAlign == 'right') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', '50%', '0', 'auto', 'auto', 'translate(0, -50%)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', '50%', '0', 'auto', 'auto', 'translate(0, -50%)']
           );
         } else if (lostAlign == 'bottom-left') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', 'auto', 'auto', '0', '0', 'translate(0, 0)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', 'auto', 'auto', '0', '0', 'translate(0, 0)']
           );
         } else if (lostAlign == 'bottom-center' || lostAlign == 'bottom') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', 'auto', 'auto', '0', '50%', 'translate(-50%, 0)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', 'auto', 'auto', '0', '50%', 'translate(-50%, 0)']
           );
         } else if (lostAlign == 'bottom-right') {
           newBlock(
-            decl,
-            ' > *',
-            ['position', 'top', 'right', 'bottom', 'left', 'transform'],
-            ['absolute', 'auto', '0', '0', 'auto', 'translate(0, 0)']
+              decl,
+              ' > *',
+              ['position', 'top', 'right', 'bottom', 'left', 'transform'],
+              ['absolute', 'auto', '0', '0', 'auto', 'translate(0, 0)']
           );
         }
       }
     } else {
       if (lostAlign == 'reset') {
         cloneAllBefore({
+          'display': 'initial',
           'display': 'flex',
           'justify-content': 'inherit',
           'align-items': 'inherit'
@@ -171,6 +172,16 @@ module.exports = function lostAlignDecl(css, settings) {
             'justify-content': 'flex-end',
             'align-items': 'flex-start'
           });
+        } else if (lostAlign == 'top-between') {
+          cloneAllBefore({
+            'justify-content': 'space-between',
+            'align-items': 'flex-start'
+          });
+        } else if (lostAlign == 'top-around') {
+          cloneAllBefore({
+            'justify-content': 'space-around',
+            'align-items': 'flex-start'
+          });
         } else if (lostAlign == 'middle-left' || lostAlign == 'left') {
           cloneAllBefore({
             'justify-content': 'flex-start',
@@ -186,6 +197,16 @@ module.exports = function lostAlignDecl(css, settings) {
             'justify-content': 'flex-end',
             'align-items': 'center'
           });
+        } else if (lostAlign == 'middle-between' || lostAlign == 'between') {
+          cloneAllBefore({
+            'justify-content': 'space-between',
+            'align-items': 'center'
+          });
+        } else if (lostAlign == 'middle-around' || lostAlign == 'around') {
+          cloneAllBefore({
+            'justify-content': 'space-around',
+            'align-items': 'center'
+          });
         } else if (lostAlign == 'bottom-left') {
           cloneAllBefore({
             'justify-content': 'flex-start',
@@ -199,6 +220,16 @@ module.exports = function lostAlignDecl(css, settings) {
         } else if (lostAlign == 'bottom-right') {
           cloneAllBefore({
             'justify-content': 'flex-end',
+            'align-items': 'flex-end'
+          });
+        } else if (lostAlign == 'bottom-between') {
+          cloneAllBefore({
+            'justify-content': 'space-between',
+            'align-items': 'flex-end'
+          });
+        } else if (lostAlign == 'bottom-around') {
+          cloneAllBefore({
+            'justify-content': 'space-around',
             'align-items': 'flex-end'
           });
         }

--- a/lib/lost-align.js
+++ b/lib/lost-align.js
@@ -136,7 +136,6 @@ module.exports = function lostAlignDecl(css, settings) {
     } else {
       if (lostAlign == 'reset') {
         cloneAllBefore({
-          'display': 'initial',
           'display': 'flex',
           'justify-content': 'inherit',
           'align-items': 'inherit'

--- a/lib/lost-align.js
+++ b/lib/lost-align.js
@@ -26,6 +26,11 @@ module.exports = function lostAlignDecl(css, settings) {
   css.walkDecls('lost-align', function(decl) {
     var declArr = [];
     var lostAlign;
+    var cloneAllBefore = function(props) {
+      for (var prop in props) {
+        decl.cloneBefore({prop: prop, value: props[prop]})
+      }
+    };
 
     declArr = decl.value.split(' ');
     lostAlign = declArr[0];
@@ -130,17 +135,12 @@ module.exports = function lostAlignDecl(css, settings) {
       }
     } else {
       if (lostAlign == 'reset') {
-        decl.cloneBefore({
-          prop: 'display',
-          value: 'initial'
+        cloneAllBefore({
+          'display': 'initial',
+          'display': 'flex',
+          'justify-content': 'inherit',
+          'align-items': 'inherit'
         });
-
-        newBlock(
-          decl,
-          ' > *',
-          ['justify-content', 'align-items'],
-          ['inherit', 'inherit']
-        );
       } else {
         decl.cloneBefore({
           prop: 'display',
@@ -148,82 +148,60 @@ module.exports = function lostAlignDecl(css, settings) {
         });
 
         if (lostAlign == 'horizontal') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['center', 'inherit']
-          );
+          cloneAllBefore({
+            'justify-content': 'center',
+            'align-items': 'inherit'
+          });
         } else if (lostAlign == 'vertical') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['inherit', 'center']
-          );
+          cloneAllBefore({
+            'justify-content': 'inherit',
+            'align-items': 'center'
+          });
         } else if (lostAlign == 'top-left') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['flex-start', 'flex-start']
-          );
+          cloneAllBefore({
+            'justify-content': 'flex-start',
+            'align-items': 'flex-start'
+          });
         } else if (lostAlign == 'top-center' || lostAlign == 'top') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['center', 'flex-start']
-          );
+          cloneAllBefore({
+            'justify-content': 'center',
+            'align-items': 'flex-start'
+          });
         } else if (lostAlign == 'top-right') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['flex-end', 'flex-start']
-          );
+          cloneAllBefore({
+            'justify-content': 'flex-end',
+            'align-items': 'flex-start'
+          });
         } else if (lostAlign == 'middle-left' || lostAlign == 'left') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['flex-start', 'center']
-          );
+          cloneAllBefore({
+            'justify-content': 'flex-start',
+            'align-items': 'center'
+          });
         } else if (lostAlign == 'middle-center' || lostAlign == 'center') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['center', 'center']
-          );
+          cloneAllBefore({
+            'justify-content': 'center',
+            'align-items': 'center'
+          });
         } else if (lostAlign == 'middle-right' || lostAlign == 'right') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['flex-end', 'center']
-          );
+          cloneAllBefore({
+            'justify-content': 'flex-end',
+            'align-items': 'center'
+          });
         } else if (lostAlign == 'bottom-left') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['flex-start', 'flex-end']
-          );
+          cloneAllBefore({
+            'justify-content': 'flex-start',
+            'align-items': 'flex-end'
+          });
         } else if (lostAlign == 'bottom-center' || lostAlign == 'bottom') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['center', 'flex-end']
-          );
+          cloneAllBefore({
+            'justify-content': 'center',
+            'align-items': 'flex-end'
+          });
         } else if (lostAlign == 'bottom-right') {
-          newBlock(
-            decl,
-            ' > *',
-            ['justify-content', 'align-items'],
-            ['flex-end', 'flex-end']
-          );
+          cloneAllBefore({
+            'justify-content': 'flex-end',
+            'align-items': 'flex-end'
+          });
         }
       }
     }

--- a/test/lost-align.js
+++ b/test/lost-align.js
@@ -160,136 +160,119 @@ describe('lost-align', function() {
     it('resets the alignment', function() {
       check(
         'a { lost-align: reset flex; }',
-        'a { display: initial; }\n' +
-        'a > * { justify-content: inherit; align-items: inherit; }'
+        'a { display: flex; justify-content: inherit; align-items: inherit; }'
       );
     });
 
     it('aligns horizontally', function() {
       check(
         'a { lost-align: horizontal flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: center; align-items: inherit; }'
+        'a { display: flex; justify-content: center; align-items: inherit; }'
       );
     });
 
     it('aligns vertically', function() {
       check(
         'a { lost-align: vertical flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: inherit; align-items: center; }'
+        'a { display: flex; justify-content: inherit; align-items: center; }'
       );
     });
 
     it('aligns top left', function() {
       check(
         'a { lost-align: top-left flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-start; align-items: flex-start; }'
+        'a { display: flex; justify-content: flex-start; align-items: flex-start; }'
       );
     });
 
     it('aligns top center', function() {
       check(
         'a { lost-align: top-center flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: center; align-items: flex-start; }'
+        'a { display: flex; justify-content: center; align-items: flex-start; }'
       );
     });
 
     it('aligns top', function() {
       check(
         'a { lost-align: top flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: center; align-items: flex-start; }'
+        'a { display: flex; justify-content: center; align-items: flex-start; }'
       );
     });
 
     it('aligns top right', function() {
       check(
         'a { lost-align: top-right flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-end; align-items: flex-start; }'
+        'a { display: flex; justify-content: flex-end; align-items: flex-start; }'
       );
     });
 
     it('aligns middle left', function() {
       check(
         'a { lost-align: middle-left flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-start; align-items: center; }'
+        'a { display: flex; justify-content: flex-start; align-items: center; }'
       );
     });
 
     it('aligns left', function() {
       check(
         'a { lost-align: left flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-start; align-items: center; }'
+        'a { display: flex; justify-content: flex-start; align-items: center; }'
       );
     });
 
     it('aligns middle center', function() {
       check(
         'a { lost-align: middle-center flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: center; align-items: center; }'
+        'a { display: flex; justify-content: center; align-items: center; }'
       );
     });
 
     it('aligns center', function() {
       check(
         'a { lost-align: center flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: center; align-items: center; }'
+        'a { display: flex; justify-content: center; align-items: center; }'
       );
     });
 
     it('aligns middle right', function() {
       check(
         'a { lost-align: middle-right flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-end; align-items: center; }'
+        'a { display: flex; justify-content: flex-end; align-items: center; }'
       );
     });
 
     it('aligns right', function() {
       check(
         'a { lost-align: right flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-end; align-items: center; }'
+        'a { display: flex; justify-content: flex-end; align-items: center; }'
       );
     });
 
     it('aligns bottom left', function() {
       check(
         'a { lost-align: bottom-left flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-start; align-items: flex-end; }'
+        'a { display: flex; justify-content: flex-start; align-items: flex-end; }'
       );
     });
 
     it('aligns bottom center', function() {
       check(
         'a { lost-align: bottom-center flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: center; align-items: flex-end; }'
+        'a { display: flex; justify-content: center; align-items: flex-end; }'
       );
     });
 
     it('aligns bottom', function() {
       check(
         'a { lost-align: bottom flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: center; align-items: flex-end; }'
+        'a { display: flex; justify-content: center; align-items: flex-end; }'
       );
     });
 
     it('aligns bottom right', function() {
       check(
         'a { lost-align: bottom-right flex; }',
-        'a { display: flex; }\n' +
-        'a > * { justify-content: flex-end; align-items: flex-end; }'
+        'a { display: flex; justify-content: flex-end; align-items: flex-end; }'
       );
     });
   });

--- a/test/lost-align.js
+++ b/test/lost-align.js
@@ -206,6 +206,20 @@ describe('lost-align', function() {
       );
     });
 
+    it('aligns top between', function() {
+      check(
+        'a { lost-align: top-between flex; }',
+        'a { display: flex; justify-content: space-between; align-items: flex-start; }'
+      );
+    });
+
+    it('aligns top around', function() {
+      check(
+        'a { lost-align: top-around flex; }',
+        'a { display: flex; justify-content: space-around; align-items: flex-start; }'
+      );
+    });
+
     it('aligns middle left', function() {
       check(
         'a { lost-align: middle-left flex; }',
@@ -248,6 +262,34 @@ describe('lost-align', function() {
       );
     });
 
+    it('aligns middle between', function() {
+      check(
+        'a { lost-align: middle-between flex; }',
+        'a { display: flex; justify-content: space-between; align-items: center; }'
+      );
+    });
+
+    it('aligns between', function() {
+      check(
+        'a { lost-align: between flex; }',
+        'a { display: flex; justify-content: space-between; align-items: center; }'
+      );
+    });
+
+    it('aligns middle around', function() {
+      check(
+        'a { lost-align: middle-around flex; }',
+        'a { display: flex; justify-content: space-around; align-items: center; }'
+      );
+    });
+
+    it('aligns around', function() {
+      check(
+        'a { lost-align: around flex; }',
+        'a { display: flex; justify-content: space-around; align-items: center; }'
+      );
+    });
+
     it('aligns bottom left', function() {
       check(
         'a { lost-align: bottom-left flex; }',
@@ -273,6 +315,20 @@ describe('lost-align', function() {
       check(
         'a { lost-align: bottom-right flex; }',
         'a { display: flex; justify-content: flex-end; align-items: flex-end; }'
+      );
+    });
+
+    it('aligns bottom between', function() {
+      check(
+        'a { lost-align: bottom-between flex; }',
+        'a { display: flex; justify-content: space-between; align-items: flex-end; }'
+      );
+    });
+
+    it('aligns bottom around', function() {
+      check(
+        'a { lost-align: bottom-around flex; }',
+        'a { display: flex; justify-content: space-around; align-items: flex-end; }'
       );
     });
   });


### PR DESCRIPTION
Adds the `space-betwen` and `space-around` flex alignment properties.
The `lost-align` property now accepts `top-between`, `top-around`, `middle-between` and `middle-around`(same as just `between` and `around`, respectively) and `bottom-between` and `bottom-around`.
