### PR TITLE
Fixes lost-column too much code generation

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -131,6 +131,7 @@ module.exports = function lostColumnDecl(css, settings) {
           ['margin-right'],
           [lostColumnGutter]
         );
+
       } else {
         if (lostColumnCycle !== 0) {
           newBlock(
@@ -143,17 +144,17 @@ module.exports = function lostColumnDecl(css, settings) {
           newBlock(
             decl,
             ':nth-child('+ lostColumnCycle +'n)',
-            ['margin-right'],
-            [0]
+            ['margin-right', 'float'],
+            [0, 'right']
+          );
+        } else {
+          newBlock(
+            decl,
+            ':nth-child('+ lostColumnCycle +'n)',
+            ['float'],
+            ['right']
           );
         }
-
-        newBlock(
-          decl,
-          ':nth-child('+ lostColumnCycle +'n)',
-          ['float'],
-          ['right']
-        );
 
         newBlock(
           decl,

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -9,8 +9,7 @@ describe('lost-column', function() {
       'a { width: calc(99.99% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
-      'a:nth-child(3n) { float: right; }\n' +
-      'a:nth-child(3n) { margin-right: 0; }\n' +
+      'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
       'a:nth-child(3n + 1) { clear: left; }'
     );
   });
@@ -21,8 +20,7 @@ describe('lost-column', function() {
       'a { width: calc(99.99% * 2/5 - (30px - 30px * 2/5)); }\n' +
       'a:nth-child(n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
-      'a:nth-child(5n) { float: right; }\n' +
-      'a:nth-child(5n) { margin-right: 0; }\n' +
+      'a:nth-child(5n) { margin-right: 0; float: right; }\n' +
       'a:nth-child(5n + 1) { clear: left; }'
     );
   });
@@ -33,8 +31,7 @@ describe('lost-column', function() {
       'a { width: calc(99.99% * 2/4 - (30px - 30px * 2/4)); }\n' +
       'a:nth-child(n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
-      'a:nth-child(2n) { float: right; }\n' +
-      'a:nth-child(2n) { margin-right: 0; }\n' +
+      'a:nth-child(2n) { margin-right: 0; float: right; }\n' +
       'a:nth-child(2n + 1) { clear: left; }'
     );
   });
@@ -45,8 +42,7 @@ describe('lost-column', function() {
       'a { width: calc(99.999999% * 2/5); }\n' +
       'a:nth-child(n) { float: left; margin-right: 0; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
-      'a:nth-child(3n) { float: right; }\n' +
-      'a:nth-child(3n) { margin-right: 0; }\n' +
+      'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
       'a:nth-child(3n + 1) { clear: left; }'
     );
   });


### PR DESCRIPTION
Fixes the issue #256 where lost-column generates two identical css selectors, each with it's own rule, instead of combining them into one.

For example:

``` css
.mydiv:nth-child(4n){
  float: right; }
.mydiv:nth-child(4n){
  margin-right: 0; }
```

Should instead be combined into:

``` css
.mydiv:nth-child(4n){
  float: right;
  margin-right: 0;
 }
```
