### PR TITLE
Fix 1px rounding issue for flexbox grids in Safari #260

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -106,17 +106,10 @@ module.exports = function lostColumnDecl(css, settings) {
           newBlock(
             decl,
             ':nth-child('+ lostColumnCycle +'n)',
-            ['margin-right'],
-            [0]
+            ['margin-right', 'margin-left'],
+            [0, 'auto']
           );
         }
-
-        newBlock(
-          decl,
-          ':nth-child('+ lostColumnCycle +'n)',
-          ['float'],
-          ['right']
-        );
 
         newBlock(
           decl,

--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -121,8 +121,8 @@ module.exports = function lostColumnDecl(css, settings) {
         newBlock(
           decl,
           ':nth-child(1n)',
-          ['margin-right'],
-          [lostColumnGutter]
+          ['margin-right', 'margin-left'],
+          [lostColumnGutter, 0]
         );
 
       } else {

--- a/lib/lost-waffle.js
+++ b/lib/lost-waffle.js
@@ -111,8 +111,8 @@ module.exports = function lostWaffleDecl(css, settings) {
         newBlock(
           decl,
           ':nth-child('+ lostWaffleCycle + 'n)',
-          ['margin-right', 'float'],
-          [0, 'right']
+          ['margin-right', 'margin-left'],
+          [0, 'auto']
         );
       }
 

--- a/lib/lost-waffle.js
+++ b/lib/lost-waffle.js
@@ -126,8 +126,8 @@ module.exports = function lostWaffleDecl(css, settings) {
       newBlock(
         decl,
         ':nth-child(1n)',
-        ['margin-right', 'margin-bottom'],
-        [lostWaffleGutter, lostWaffleGutter]
+        ['margin-right', 'margin-bottom', 'margin-left'],
+        [lostWaffleGutter, lostWaffleGutter, 0]
       );
     } else {
       if (lostWaffleCycle !== 0) {

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -52,7 +52,7 @@ describe('lost-column', function() {
       'a { lost-column: 2/6 3 60px flex; }',
       'a { flex: 0 0 auto; width: calc(99.99% * 2/6 - (60px - 60px * 2/6));' +
       ' }\n' +
-      'a:nth-child(1n) { margin-right: 60px; }\n' +
+      'a:nth-child(1n) { margin-right: 60px; margin-left: 0; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; margin-left: auto; }'
     );

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -54,8 +54,7 @@ describe('lost-column', function() {
       ' }\n' +
       'a:nth-child(1n) { margin-right: 60px; }\n' +
       'a:last-child { margin-right: 0; }\n' +
-      'a:nth-child(3n) { float: right; }\n' +
-      'a:nth-child(3n) { margin-right: 0; }'
+      'a:nth-child(3n) { margin-right: 0; margin-left: auto; }'
     );
   });
   it('provides none rule', function() {

--- a/test/lost-waffle.js
+++ b/test/lost-waffle.js
@@ -50,7 +50,7 @@ describe('lost-waffle', function() {
       'a { lost-waffle: 2/5 3 0 flex; }',
       'a { flex: 0 0 auto; width: calc(99.999999% * 2/5);' +
       ' height: calc(99.999999% * 2/5); }\n' +
-      'a:nth-child(1n) { margin-right: 0; margin-bottom: 0; }\n' +
+      'a:nth-child(1n) { margin-right: 0; margin-bottom: 0; margin-left: 0; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; margin-left: auto; }\n' +
       'a:nth-last-child(-n + 3) { margin-bottom: 0; }'

--- a/test/lost-waffle.js
+++ b/test/lost-waffle.js
@@ -52,7 +52,7 @@ describe('lost-waffle', function() {
       ' height: calc(99.999999% * 2/5); }\n' +
       'a:nth-child(1n) { margin-right: 0; margin-bottom: 0; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
-      'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
+      'a:nth-child(3n) { margin-right: 0; margin-left: auto; }\n' +
       'a:nth-last-child(-n + 3) { margin-bottom: 0; }'
     );
   });


### PR DESCRIPTION
Remove unneeded `float: right` for flexbox grids and replaced with `margin-left: auto`. Fixes #260 and #200.

Also remove on rule duplicating.

[Codepen with compiled code](http://codepen.io/hudochenkov/full/XXQpZj/).
