### PR TITLE
Removes duplicate line of code for lost-column: none;

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -184,13 +184,6 @@ module.exports = function lostColumnDecl(css, settings) {
 
       newBlock(
         decl,
-        ':nth-child(1n)',
-        ['float', 'clear', 'margin-right', 'width'],
-        ['none', 'none', 0, 'auto']
-      );
-
-      newBlock(
-        decl,
         ':nth-child(1n + 1)',
         ['float', 'clear', 'margin-right', 'width'],
         ['none', 'none', 0, 'auto']

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -63,8 +63,7 @@ describe('lost-column', function() {
       'a { width: auto; }\n' +
       'a:last-child { float: none; clear: none; margin-right: 0; width: auto; }\n' +
       'a:nth-child(1n) { float: none; clear: none; margin-right: 0; width: auto; }\n' +
-      'a:nth-child(1n + 1) { float: none; clear: none; margin-right: 0; width: auto; }\n' +
-      'a:nth-child(1n) { float: none; clear: none; margin-right: 0; width: auto; }'
+      'a:nth-child(1n + 1) { float: none; clear: none; margin-right: 0; width: auto; }'
     );
   });
 });


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Fix

**What is the current behavior (You can also link to an issue)**
See issue: #285 
Currently 

``` css
.foo {
  lost-column: none;
}
```

outputs:

``` css
.foo {
  width: auto;
}
.foo:last-child {
  float: none;
  clear: none;
  margin-right: 0;
  width: auto;
}
.foo:nth-child(1n) {
  float: none;
  clear: none;
  margin-right: 0;
  width: auto;
}
.foo:nth-child(1n + 1) {
  float: none;
  clear: none;
  margin-right: 0;
  width: auto;
}
.foo:nth-child(1n) {
  float: none;
  clear: none;
  margin-right: 0;
  width: auto;
}
```

**What is the new behavior this introduces (if any)**

``` css
.foo {
  lost-column: none;
}
```

Now outputs:

``` css
.foo {
  width: auto;
}
.foo:last-child {
  float: none;
  clear: none;
  margin-right: 0;
  width: auto;
}
.foo:nth-child(1n) {
  float: none;
  clear: none;
  margin-right: 0;
  width: auto;
}
.foo:nth-child(1n + 1) {
  float: none;
  clear: none;
  margin-right: 0;
  width: auto;
}
```

**Does this introduce any breaking changes?**
I sure hope not!

**Does the PR fulfill the these requirements?**
- [x] Tests for the changes have been added
- ~~[ ] Docs have been added or updated~~

**Other Comments**

There was a duplicate line of code that must have been some copy pasta
when I added this. This should remove it.
