### PR TITLE
Updates the "clear" rule from "left" to "both"

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,15 +455,18 @@ Lost uses PostCSS which means to override global variables we need to use someth
 @lost gutter 60px;
 @lost flexbox flex;
 @lost cycle none;
+@lost clearing left
 
 .foo {
   ...
 }
 ```
 
-- `gutter` accepts any unit value. `30px` by default.
+- `gutter` accepts any unit value. `30px` (default).
 - `flexbox` accepts `flex` or `no-flex` (default).
 - `cycle` accepts `none` or any digit (although this is really weird). `auto` by default.
+- `clearing` accepts `left` or `both` (default).
+  - See [#276](https://github.com/peterramsing/lost/issues/276) for details
 
 **[:arrow_up: back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ div:nth-child(3n) {
   float: right;
 }
 div:nth-child(3n + 1) {
-  clear: left;
+  clear: both;
 }
 ```
 

--- a/lib/lost-at-rule.js
+++ b/lib/lost-at-rule.js
@@ -12,6 +12,9 @@ module.exports = function lostAtRule(css, settings) {
   css.walkAtRules('lost', function(rule) {
     rule.params = rule.params.split(' ');
 
+    if (rule.params[0] == 'clearing') {
+      settings.clearing = rule.params[1];
+    }
     if (rule.params[0] == 'gutter') {
       settings.gutter = rule.params[1];
     }

--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -127,12 +127,22 @@ module.exports = function lostColumnDecl(css, settings) {
 
       } else {
         if (lostColumnCycle !== 0) {
-          newBlock(
-            decl,
-            ':nth-child('+ lostColumnCycle +'n + 1)',
-            ['clear'],
-            ['left']
-          );
+
+          if (settings.clearing === 'left') {
+            newBlock(
+              decl,
+              ':nth-child('+ lostColumnCycle +'n + 1)',
+              ['clear'],
+              ['left']
+            );
+          } else {
+            newBlock(
+              decl,
+              ':nth-child('+ lostColumnCycle +'n + 1)',
+              ['clear'],
+              ['both']
+            );
+          }
 
           newBlock(
             decl,
@@ -181,13 +191,6 @@ module.exports = function lostColumnDecl(css, settings) {
         prop: 'width',
         value: 'auto'
       });
-
-      newBlock(
-        decl,
-        ':nth-child(1n)',
-        ['float', 'clear', 'margin-right', 'width'],
-        ['none', 'none', 0, 'auto']
-      );
 
       newBlock(
         decl,

--- a/lib/lost-waffle.js
+++ b/lib/lost-waffle.js
@@ -138,12 +138,21 @@ module.exports = function lostWaffleDecl(css, settings) {
           [0]
         );
 
-        newBlock(
-          decl,
-          ':nth-child('+ lostWaffleCycle +'n + 1)',
-          ['clear'],
-          ['left']
-        );
+        if (settings.clearing === 'left') {
+          newBlock(
+            decl,
+            ':nth-child('+ lostWaffleCycle +'n + 1)',
+            ['clear'],
+            ['left']
+          );
+        } else {
+          newBlock(
+            decl,
+            ':nth-child('+ lostWaffleCycle +'n + 1)',
+            ['clear'],
+            ['both']
+          );
+        }
 
         newBlock(
           decl,

--- a/lost.js
+++ b/lost.js
@@ -21,7 +21,8 @@ var libs = [
 var defaultSettings = {
   gutter: '30px',
   flexbox: 'no-flex',
-  cycle: 'auto'
+  cycle: 'auto',
+  clearing: 'both'
 };
 
 module.exports = postcss.plugin('lost', function lost(settings) {

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -70,6 +70,14 @@ describe('lost-column', function() {
     );
   });
 
+
+  it('reverts global back to default', function() {
+    check(
+      '@lost clearing both',
+      ''
+    );
+  });
+
   it('provides none rule', function() {
     check(
       'a { lost-column: none; }',

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -10,7 +10,7 @@ describe('lost-column', function() {
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
-      'a:nth-child(3n + 1) { clear: left; }'
+      'a:nth-child(3n + 1) { clear: both; }'
     );
   });
 
@@ -21,7 +21,7 @@ describe('lost-column', function() {
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(5n) { margin-right: 0; float: right; }\n' +
-      'a:nth-child(5n + 1) { clear: left; }'
+      'a:nth-child(5n + 1) { clear: both; }'
     );
   });
 
@@ -32,7 +32,7 @@ describe('lost-column', function() {
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(2n) { margin-right: 0; float: right; }\n' +
-      'a:nth-child(2n + 1) { clear: left; }'
+      'a:nth-child(2n + 1) { clear: both; }'
     );
   });
 
@@ -43,7 +43,7 @@ describe('lost-column', function() {
       'a:nth-child(1n) { float: left; margin-right: 0; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
-      'a:nth-child(3n + 1) { clear: left; }'
+      'a:nth-child(3n + 1) { clear: both; }'
     );
   });
 
@@ -57,14 +57,26 @@ describe('lost-column', function() {
       'a:nth-child(3n) { margin-right: 0; margin-left: auto; }'
     );
   });
+
+  it('supports clearing fallback', function() {
+    check(
+      '@lost clearing left; \n' +
+      'a { lost-column: 1/3; }',
+      'a { width: calc(99.99% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
+      'a:last-child { margin-right: 0; }\n' +
+      'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
+      'a:nth-child(3n + 1) { clear: left; }'
+    );
+  });
+
   it('provides none rule', function() {
     check(
       'a { lost-column: none; }',
       'a { width: auto; }\n' +
       'a:last-child { float: none; clear: none; margin-right: 0; width: auto; }\n' +
       'a:nth-child(1n) { float: none; clear: none; margin-right: 0; width: auto; }\n' +
-      'a:nth-child(1n + 1) { float: none; clear: none; margin-right: 0; width: auto; }\n' +
-      'a:nth-child(1n) { float: none; clear: none; margin-right: 0; width: auto; }'
+      'a:nth-child(1n + 1) { float: none; clear: none; margin-right: 0; width: auto; }'
     );
   });
 });

--- a/test/lost-waffle.js
+++ b/test/lost-waffle.js
@@ -12,7 +12,7 @@ describe('lost-waffle', function() {
       ' margin-bottom: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
-      'a:nth-child(3n + 1) { clear: left; }\n' +
+      'a:nth-child(3n + 1) { clear: both; }\n' +
       'a:nth-last-child(-n + 3) { margin-bottom: 0; }'
     );
   });
@@ -26,7 +26,7 @@ describe('lost-waffle', function() {
       ' margin-bottom: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
       'a:nth-child(2n) { margin-right: 0; float: right; }\n' +
-      'a:nth-child(2n + 1) { clear: left; }\n' +
+      'a:nth-child(2n + 1) { clear: both; }\n' +
       'a:nth-last-child(-n + 2) { margin-bottom: 0; }'
     );
   });
@@ -40,8 +40,30 @@ describe('lost-waffle', function() {
       ' margin-bottom: 60px; clear: none; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
       'a:nth-child(2n) { margin-right: 0; float: right; }\n' +
-      'a:nth-child(2n + 1) { clear: left; }\n' +
+      'a:nth-child(2n + 1) { clear: both; }\n' +
       'a:nth-last-child(-n + 2) { margin-bottom: 0; }'
+    );
+  });
+
+  it('supports clearing fallback', function() {
+    check(
+      '@lost clearing left; \n' +
+      'a { lost-waffle: 1/3; }',
+      'a { width: calc(99.99% * 1/3 - (30px - 30px * 1/3));' +
+      ' height: calc(99.99% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a:nth-child(1n) { float: left; margin-right: 30px;' +
+      ' margin-bottom: 30px; clear: none; }\n' +
+      'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
+      'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
+      'a:nth-child(3n + 1) { clear: left; }\n' +
+      'a:nth-last-child(-n + 3) { margin-bottom: 0; }'
+    );
+  });
+
+  it('reverts global back to default', function() {
+    check(
+      '@lost clearing both',
+      ''
     );
   });
 


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Bug Fix

**What is the current behavior (You can also link to an issue)**
Currently in `lost-column` and `lost-grid` this happens for the following code:

``` css
section {
    lost-center: 940px 10px;
    lost-utility: edit;
}

section .col-1-2 {
  lost-column/waffle: 1/2;
  margin-bottom: 21px;
  height: 80px;
}
section .second {
  height: 120px;
}
```

``` css
section .col-1-2:nth-child(2n + 1) {
    clear: left;
}
```

![image](https://cloud.githubusercontent.com/assets/3523268/15461072/60b0e0f8-206c-11e6-86b3-2ef2408bd5d5.png)

**What is the new behavior this introduces (if any)**

``` css
section .col-1-2 {
  lost-column/waffle: 1/2;
}
```

``` css
section .col-1-2:nth-child(2n + 1) {
    clear: both;
}
```

![image](https://cloud.githubusercontent.com/assets/3523268/15461114/c32c9574-206c-11e6-83b9-936fc8327281.png)

**Does this introduce any breaking changes?**
Yes. `clear: left` is now `clear: both`.
The update path if this causes undesired changes is to update `@lost clearing left;` to revert to the previous behaviour.

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

**Other Comments**
See: #276 
