### PR TITLE
change size from 99.99% to 99.9% to avoid rounding errors in Edge and IE

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ And the processed CSS looks like this:
 
 ```css
 div {
-  width: calc(99.99% * 1/3 - (30px - 30px * 1/3));
+  width: calc(99.9% * 1/3 - (30px - 30px * 1/3));
 }
 div:nth-child(1n) {
   float: left;

--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -177,12 +177,12 @@ module.exports = function lostColumnDecl(css, settings) {
       if (lostColumnGutter !== '0') {
         decl.cloneBefore({
           prop: 'width',
-          value: 'calc(99.99% * '+ lostColumn +' - ('+ lostColumnGutter +' - '+ lostColumnGutter +' * '+ lostColumn +'))'
+          value: 'calc(99.9% * '+ lostColumn +' - ('+ lostColumnGutter +' - '+ lostColumnGutter +' * '+ lostColumn +'))'
         });
       } else {
         decl.cloneBefore({
           prop: 'width',
-          value: 'calc(99.999999% * '+ lostColumn +')'
+          value: 'calc(99.9% * '+ lostColumn +')'
         });
       }
     } else {

--- a/lib/lost-masonry-column.js
+++ b/lib/lost-masonry-column.js
@@ -80,7 +80,7 @@ module.exports = function lostMasonryColumnDecl(css, settings) {
     if (lostMasonryColumnGutter !== '0') {
       decl.cloneBefore({
         prop: 'width',
-        value: 'calc(99.99% * '+ lostMasonryColumn +' - '+ lostMasonryColumnGutter +')'
+        value: 'calc(99.9% * '+ lostMasonryColumn +' - '+ lostMasonryColumnGutter +')'
       });
 
       decl.cloneBefore({

--- a/lib/lost-move.js
+++ b/lib/lost-move.js
@@ -66,7 +66,7 @@ module.exports = function lostMoveDecl(css, settings) {
       if (lostMoveGutter !== '0') {
         decl.cloneBefore({
           prop: 'top',
-          value: 'calc(99.99% * '+ lostMove +' - ('+ lostMoveGutter +' - '+ lostMoveGutter +' * '+ lostMove +') + '+ lostMoveGutter +')'
+          value: 'calc(99.9% * '+ lostMove +' - ('+ lostMoveGutter +' - '+ lostMoveGutter +' * '+ lostMove +') + '+ lostMoveGutter +')'
         });
       } else {
         decl.cloneBefore({
@@ -78,7 +78,7 @@ module.exports = function lostMoveDecl(css, settings) {
       if (lostMoveGutter !== '0') {
         decl.cloneBefore({
           prop: 'left',
-          value: 'calc(99.99% * '+ lostMove +' - ('+ lostMoveGutter +' - '+ lostMoveGutter +' * '+ lostMove +') + '+ lostMoveGutter +')'
+          value: 'calc(99.9% * '+ lostMove +' - ('+ lostMoveGutter +' - '+ lostMoveGutter +' * '+ lostMove +') + '+ lostMoveGutter +')'
         });
       } else {
         decl.cloneBefore({

--- a/lib/lost-offset.js
+++ b/lib/lost-offset.js
@@ -62,7 +62,7 @@ module.exports = function lostOffsetDecl(css, settings) {
         if (lostOffsetGutter !== '0') {
           decl.cloneBefore({
             prop: 'margin-bottom',
-            value: 'calc(99.99% * '+ lostOffset +' - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * '+ lostOffset +') + ('+ lostOffsetGutter +' * 2)) !important'
+            value: 'calc(99.9% * '+ lostOffset +' - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * '+ lostOffset +') + ('+ lostOffsetGutter +' * 2)) !important'
           });
         } else {
           decl.cloneBefore({
@@ -74,7 +74,7 @@ module.exports = function lostOffsetDecl(css, settings) {
         if (lostOffsetGutter !== '0') {
           decl.cloneBefore({
             prop: 'margin-top',
-            value: 'calc(99.99% * ('+ lostOffset +' * -1) - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * ('+ lostOffset +' * -1)) + '+ lostOffsetGutter +') !important'
+            value: 'calc(99.9% * ('+ lostOffset +' * -1) - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * ('+ lostOffset +' * -1)) + '+ lostOffsetGutter +') !important'
           });
         } else {
           decl.cloneBefore({
@@ -98,7 +98,7 @@ module.exports = function lostOffsetDecl(css, settings) {
         if (lostOffsetGutter !== '0') {
           decl.cloneBefore({
             prop: 'margin-right',
-            value: 'calc(99.99% * '+ lostOffset +' - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * '+ lostOffset +') + ('+ lostOffsetGutter +' * 2)) !important'
+            value: 'calc(99.9% * '+ lostOffset +' - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * '+ lostOffset +') + ('+ lostOffsetGutter +' * 2)) !important'
           });
         } else {
           decl.cloneBefore({
@@ -110,7 +110,7 @@ module.exports = function lostOffsetDecl(css, settings) {
         if (lostOffsetGutter !== '0') {
           decl.cloneBefore({
             prop: 'margin-left',
-            value: 'calc(99.99% * ('+ lostOffset +' * -1) - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * ('+ lostOffset +' * -1)) + '+ lostOffsetGutter +') !important'
+            value: 'calc(99.9% * ('+ lostOffset +' * -1) - ('+ lostOffsetGutter +' - '+ lostOffsetGutter +' * ('+ lostOffset +' * -1)) + '+ lostOffsetGutter +') !important'
           });
         } else {
           decl.cloneBefore({

--- a/lib/lost-row.js
+++ b/lib/lost-row.js
@@ -79,7 +79,7 @@ module.exports = function lostRowDecl(css, settings) {
     if (lostRowGutter !== '0') {
       decl.cloneBefore({
         prop: 'height',
-        value: 'calc(99.99% * '+ lostRow +' - ('+ lostRowGutter +' - '+ lostRowGutter +' * '+ lostRow +'))'
+        value: 'calc(99.9% * '+ lostRow +' - ('+ lostRowGutter +' - '+ lostRowGutter +' * '+ lostRow +'))'
       });
     } else {
       decl.cloneBefore({

--- a/lib/lost-waffle.js
+++ b/lib/lost-waffle.js
@@ -180,12 +180,12 @@ module.exports = function lostWaffleDecl(css, settings) {
     if (lostWaffleGutter !== '0') {
       decl.cloneBefore({
         prop: 'width',
-        value: 'calc(99.99% * '+ lostWaffle +' - ('+ lostWaffleGutter +' - '+ lostWaffleGutter +' * '+ lostWaffle +'))'
+        value: 'calc(99.9% * '+ lostWaffle +' - ('+ lostWaffleGutter +' - '+ lostWaffleGutter +' * '+ lostWaffle +'))'
       });
 
       decl.cloneBefore({
         prop: 'height',
-        value: 'calc(99.99% * '+ lostWaffle +' - ('+ lostWaffleGutter +' - '+ lostWaffleGutter +' * '+ lostWaffle +'))'
+        value: 'calc(99.9% * '+ lostWaffle +' - ('+ lostWaffleGutter +' - '+ lostWaffleGutter +' * '+ lostWaffle +'))'
       });
     } else {
       decl.cloneBefore({

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -6,7 +6,7 @@ describe('lost-column', function() {
   it('provides 3 column layout', function() {
     check(
       'a { lost-column: 1/3; }',
-      'a { width: calc(99.99% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
@@ -17,7 +17,7 @@ describe('lost-column', function() {
   it('provides 2/5 column layout', function() {
     check(
       'a { lost-column: 2/5; }',
-      'a { width: calc(99.99% * 2/5 - (30px - 30px * 2/5)); }\n' +
+      'a { width: calc(99.9% * 2/5 - (30px - 30px * 2/5)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(5n) { margin-right: 0; float: right; }\n' +
@@ -28,7 +28,7 @@ describe('lost-column', function() {
   it('can support custom cycle', function() {
     check(
       'a { lost-column: 2/4 2; }',
-      'a { width: calc(99.99% * 2/4 - (30px - 30px * 2/4)); }\n' +
+      'a { width: calc(99.9% * 2/4 - (30px - 30px * 2/4)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(2n) { margin-right: 0; float: right; }\n' +
@@ -39,7 +39,7 @@ describe('lost-column', function() {
   it('supports no gutter', function() {
     check(
       'a { lost-column: 2/5 3 0; }',
-      'a { width: calc(99.999999% * 2/5); }\n' +
+      'a { width: calc(99.9% * 2/5); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 0; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
@@ -50,7 +50,7 @@ describe('lost-column', function() {
   it('supports flexbox', function() {
     check(
       'a { lost-column: 2/6 3 60px flex; }',
-      'a { flex: 0 0 auto; width: calc(99.99% * 2/6 - (60px - 60px * 2/6));' +
+      'a { flex: 0 0 auto; width: calc(99.9% * 2/6 - (60px - 60px * 2/6));' +
       ' }\n' +
       'a:nth-child(1n) { margin-right: 60px; margin-left: 0; }\n' +
       'a:last-child { margin-right: 0; }\n' +

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -62,7 +62,7 @@ describe('lost-column', function() {
     check(
       '@lost clearing left; \n' +
       'a { lost-column: 1/3; }',
-      'a { width: calc(99.99% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +

--- a/test/lost-masonry-column.js
+++ b/test/lost-masonry-column.js
@@ -6,7 +6,7 @@ describe('lost-masonry-column', function() {
   it('supports a custom gutter', function() {
     check(
       'a { lost-masonry-column: 60px; }',
-      'a { float: left; width: calc(99.99% * 60px - 30px); margin-left: 15px;' +
+      'a { float: left; width: calc(99.9% * 60px - 30px); margin-left: 15px;' +
       ' margin-right: 15px; }'
     );
   });
@@ -14,7 +14,7 @@ describe('lost-masonry-column', function() {
   it('supports no gutter', function() {
     check(
       'a { lost-masonry-column: 0; }',
-      'a { float: left; width: calc(99.99% * 0 - 30px); margin-left: 15px;' +
+      'a { float: left; width: calc(99.9% * 0 - 30px); margin-left: 15px;' +
       ' margin-right: 15px; }'
     );
   });
@@ -23,7 +23,7 @@ describe('lost-masonry-column', function() {
     it('supports a custom gutter', function() {
       check(
         'a { lost-masonry-column: 60px flex; }',
-        'a { flex: 0 0 auto; width: calc(99.99% * 60px - 30px);' +
+        'a { flex: 0 0 auto; width: calc(99.9% * 60px - 30px);' +
         ' margin-left: 15px; margin-right: 15px; }'
       );
     });
@@ -31,7 +31,7 @@ describe('lost-masonry-column', function() {
     it('supports no gutter', function() {
       check(
         'a { lost-masonry-column: 0 flex; }',
-        'a { flex: 0 0 auto; width: calc(99.99% * 0 - 30px);' +
+        'a { flex: 0 0 auto; width: calc(99.9% * 0 - 30px);' +
         ' margin-left: 15px; margin-right: 15px; }'
       );
     });

--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -6,7 +6,7 @@ describe('lost-move', function() {
   it('moves element to the left', function() {
     check(
       'a { lost-move: 1/3; }',
-      'a { position: relative; left: calc(99.99% * 1/3 - (30px - 30px * 1/3)' +
+      'a { position: relative; left: calc(99.9% * 1/3 - (30px - 30px * 1/3)' +
       ' + 30px); }'
     );
   });
@@ -14,7 +14,7 @@ describe('lost-move', function() {
   it('moves element to the right', function() {
     check(
       'a { lost-move: -1/3; }',
-      'a { position: relative; left: calc(99.99% * -1/3 -' +
+      'a { position: relative; left: calc(99.9% * -1/3 -' +
       ' (30px - 30px * -1/3) + 30px); }'
     );
   });
@@ -22,7 +22,7 @@ describe('lost-move', function() {
   it('moves element up', function() {
     check(
       'a { lost-move: 1/3 column; }',
-      'a { position: relative; top: calc(99.99% * 1/3 - (30px - 30px * 1/3)' +
+      'a { position: relative; top: calc(99.9% * 1/3 - (30px - 30px * 1/3)' +
       ' + 30px); }'
     );
   });
@@ -30,7 +30,7 @@ describe('lost-move', function() {
   it('moves element down', function() {
     check(
       'a { lost-move: -1/3 column; }',
-      'a { position: relative; top: calc(99.99% * -1/3 - (30px - 30px * -1/3)' +
+      'a { position: relative; top: calc(99.9% * -1/3 - (30px - 30px * -1/3)' +
       ' + 30px); }'
     );
   });
@@ -38,7 +38,7 @@ describe('lost-move', function() {
   it('supports custom gutter', function() {
     check(
       'a { lost-move: 1/2 row 60px; }',
-      'a { position: relative; left: calc(99.99% * 1/2 - (60px - 60px * 1/2)' +
+      'a { position: relative; left: calc(99.9% * 1/2 - (60px - 60px * 1/2)' +
       ' + 60px); }'
     );
   });

--- a/test/lost-offset.js
+++ b/test/lost-offset.js
@@ -6,7 +6,7 @@ describe('lost-offset', function() {
   it('moves element to the left', function() {
     check(
       'a { lost-offset: 1/3; }',
-      'a { margin-right: calc(99.99% * 1/3 - (30px - 30px * 1/3) + (30px * 2)' +
+      'a { margin-right: calc(99.9% * 1/3 - (30px - 30px * 1/3) + (30px * 2)' +
       ') !important; }'
     );
   });
@@ -14,7 +14,7 @@ describe('lost-offset', function() {
   it('moves element to the right', function() {
     check(
       'a { lost-offset: -1/3; }',
-      'a { margin-left: calc(99.99% * (-1/3 * -1) - (30px - 30px * ' +
+      'a { margin-left: calc(99.9% * (-1/3 * -1) - (30px - 30px * ' +
       '(-1/3 * -1)) + 30px) !important; }'
     );
   });
@@ -22,7 +22,7 @@ describe('lost-offset', function() {
   it('moves element up', function() {
     check(
       'a { lost-offset: 1/3 column; }',
-      'a { margin-bottom: calc(99.99% * 1/3 - (30px - 30px * 1/3) + ' +
+      'a { margin-bottom: calc(99.9% * 1/3 - (30px - 30px * 1/3) + ' +
       '(30px * 2)) !important; }'
     );
   });
@@ -30,7 +30,7 @@ describe('lost-offset', function() {
   it('moves element down', function() {
     check(
       'a { lost-offset: -1/3 column; }',
-      'a { margin-top: calc(99.99% * (-1/3 * -1) - (30px - 30px * ' +
+      'a { margin-top: calc(99.9% * (-1/3 * -1) - (30px - 30px * ' +
       '(-1/3 * -1)) + 30px) !important; }'
     );
   });
@@ -38,7 +38,7 @@ describe('lost-offset', function() {
   it('supports custom gutter', function() {
     check(
       'a { lost-offset: 1/2 row 60px; }',
-      'a { margin-right: calc(99.99% * 1/2 - (60px - 60px * 1/2) + ' +
+      'a { margin-right: calc(99.9% * 1/2 - (60px - 60px * 1/2) + ' +
       '(60px * 2)) !important; }'
     );
   });

--- a/test/lost-row.js
+++ b/test/lost-row.js
@@ -6,7 +6,7 @@ describe('lost-row', function() {
   it('provides 3 row layout', function() {
     check(
       'a { lost-row: 1/3; }',
-      'a { width: 100%; height: calc(99.99% * 1/3 - (30px - 30px * 1/3));' +
+      'a { width: 100%; height: calc(99.9% * 1/3 - (30px - 30px * 1/3));' +
       ' margin-bottom: 30px; }\n' +
       'a:last-child { margin-bottom: 0; }'
     );
@@ -15,7 +15,7 @@ describe('lost-row', function() {
   it('provides 2/5 row layout', function() {
     check(
       'a { lost-row: 2/5; }',
-      'a { width: 100%; height: calc(99.99% * 2/5 - (30px - 30px * 2/5));' +
+      'a { width: 100%; height: calc(99.9% * 2/5 - (30px - 30px * 2/5));' +
       ' margin-bottom: 30px; }\n' +
       'a:last-child { margin-bottom: 0; }'
     );
@@ -33,7 +33,7 @@ describe('lost-row', function() {
     check(
       'a { lost-row: 2/6 60px flex; }',
       'a { width: 100%; flex: 0 0 auto;' +
-      ' height: calc(99.99% * 2/6 - (60px - 60px * 2/6));' +
+      ' height: calc(99.9% * 2/6 - (60px - 60px * 2/6));' +
       ' margin-bottom: 60px; }\n' +
       'a:last-child { margin-bottom: 0; }'
     );

--- a/test/lost-waffle.js
+++ b/test/lost-waffle.js
@@ -49,8 +49,8 @@ describe('lost-waffle', function() {
     check(
       '@lost clearing left; \n' +
       'a { lost-waffle: 1/3; }',
-      'a { width: calc(99.99% * 1/3 - (30px - 30px * 1/3));' +
-      ' height: calc(99.99% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3));' +
+      ' height: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px;' +
       ' margin-bottom: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +

--- a/test/lost-waffle.js
+++ b/test/lost-waffle.js
@@ -6,8 +6,8 @@ describe('lost-waffle', function() {
   it('provides 3 column layout', function() {
     check(
       'a { lost-waffle: 1/3; }',
-      'a { width: calc(99.99% * 1/3 - (30px - 30px * 1/3));' +
-      ' height: calc(99.99% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3));' +
+      ' height: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px;' +
       ' margin-bottom: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
@@ -20,8 +20,8 @@ describe('lost-waffle', function() {
   it('supports a custom cycle', function() {
     check(
       'a { lost-waffle: 2/4 2; }',
-      'a { width: calc(99.99% * 2/4 - (30px - 30px * 2/4));' +
-      ' height: calc(99.99% * 2/4 - (30px - 30px * 2/4)); }\n' +
+      'a { width: calc(99.9% * 2/4 - (30px - 30px * 2/4));' +
+      ' height: calc(99.9% * 2/4 - (30px - 30px * 2/4)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px;' +
       ' margin-bottom: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +
@@ -34,8 +34,8 @@ describe('lost-waffle', function() {
   it('supports a custom gutter', function() {
     check(
       'a { lost-waffle: 3/6 2 60px; }',
-      'a { width: calc(99.99% * 3/6 - (60px - 60px * 3/6));' +
-      ' height: calc(99.99% * 3/6 - (60px - 60px * 3/6)); }\n' +
+      'a { width: calc(99.9% * 3/6 - (60px - 60px * 3/6));' +
+      ' height: calc(99.9% * 3/6 - (60px - 60px * 3/6)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 60px;' +
       ' margin-bottom: 60px; clear: none; }\n' +
       'a:last-child { margin-right: 0; margin-bottom: 0; }\n' +


### PR DESCRIPTION
This fixes #295 and is the same as #296 but with 2 changed tests in `lost-waffle.js` and `lost-column.js`, so they pass with this patch.

Based off the `beta` branch.
