### PR TITLE
Adds lost-row: none rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Creates a row that is a fraction of the size of its containing element's height 
 - `fraction` - This is a simple fraction of the containing element's height.
 - `gutter` - The margin on the bottom of the element used to create a gutter. Typically this is left alone and settings.gutter will be used, but you can override it here if you want certain elements to have a particularly large or small gutter (pass 0 for no gutter at all).
 - `flex|no-flex` - Determines whether this element should use Flexbox or not.
+- `none` - Resets the row (back to browser defaults)
 
 ```css
 section {

--- a/lib/lost-row.js
+++ b/lib/lost-row.js
@@ -31,74 +31,93 @@ module.exports = function lostRowDecl(css, settings) {
         lostRowGutter = settings.gutter,
         lostRowFlexbox = settings.flexbox;
 
-    declArr = decl.value.split(' ');
-    lostRow = declArr[0];
+    if (decl.value !== 'none') {
+      declArr = decl.value.split(' ');
+      lostRow = declArr[0];
 
-    if (declArr[1] !== undefined && declArr[1].search(/^\d/) !== -1) {
-      lostRowGutter = declArr[1];
-    }
-
-    if (declArr.indexOf('flex') !== -1) {
-      lostRowFlexbox = 'flex';
-    }
-
-    if (declArr.indexOf('no-flex') !== -1) {
-      lostRowFlexbox = 'no-flex';
-    }
-
-    decl.parent.nodes.forEach(function (decl) {
-      if (decl.prop == 'lost-row-gutter') {
-        lostRowGutter = decl.value;
-
-        decl.remove();
+      if (declArr[1] !== undefined && declArr[1].search(/^\d/) !== -1) {
+        lostRowGutter = declArr[1];
       }
-    });
 
-    decl.parent.nodes.forEach(function (decl) {
-      if (decl.prop == 'lost-row-flexbox') {
-        if (decl.prop == 'flex') {
-          lostRowFlexbox = 'flex';
+      if (declArr.indexOf('flex') !== -1) {
+        lostRowFlexbox = 'flex';
+      }
+
+      if (declArr.indexOf('no-flex') !== -1) {
+        lostRowFlexbox = 'no-flex';
+      }
+
+      decl.parent.nodes.forEach(function (decl) {
+        if (decl.prop == 'lost-row-gutter') {
+          lostRowGutter = decl.value;
+
+          decl.remove();
         }
+      });
 
-        decl.remove();
+      decl.parent.nodes.forEach(function (decl) {
+        if (decl.prop == 'lost-row-flexbox') {
+          if (decl.prop == 'flex') {
+            lostRowFlexbox = 'flex';
+          }
+
+          decl.remove();
+        }
+      });
+
+      decl.cloneBefore({
+        prop: 'width',
+        value: '100%'
+      });
+
+      if (lostRowFlexbox === 'flex') {
+        decl.cloneBefore({
+          prop: 'flex',
+          value: '0 0 auto'
+        });
       }
-    });
 
-    decl.cloneBefore({
-      prop: 'width',
-      value: '100%'
-    });
+      if (lostRowGutter !== '0') {
+        decl.cloneBefore({
+          prop: 'height',
+          value: 'calc(99.99% * '+ lostRow +' - ('+ lostRowGutter +' - '+ lostRowGutter +' * '+ lostRow +'))'
+        });
+      } else {
+        decl.cloneBefore({
+          prop: 'height',
+          value: 'calc(99.999999% * '+ lostRow +')'
+        });
+      }
 
-    if (lostRowFlexbox === 'flex') {
       decl.cloneBefore({
-        prop: 'flex',
-        value: '0 0 auto'
+        prop: 'margin-bottom',
+        value: lostRowGutter
       });
-    }
 
-    if (lostRowGutter !== '0') {
-      decl.cloneBefore({
-        prop: 'height',
-        value: 'calc(99.99% * '+ lostRow +' - ('+ lostRowGutter +' - '+ lostRowGutter +' * '+ lostRow +'))'
-      });
+      newBlock(
+        decl,
+        ':last-child',
+        ['margin-bottom'],
+        [0]
+      );
     } else {
       decl.cloneBefore({
+        prop: 'width',
+        value: 'auto'
+      });
+
+      decl.cloneBefore({
         prop: 'height',
-        value: 'calc(99.999999% * '+ lostRow +')'
+        value: 'auto'
+      });
+
+      decl.cloneBefore({
+        prop: 'margin-bottom',
+        value: '0'
       });
     }
 
-    decl.cloneBefore({
-      prop: 'margin-bottom',
-      value: lostRowGutter
-    });
 
-    newBlock(
-      decl,
-      ':last-child',
-      ['margin-bottom'],
-      [0]
-    );
 
     decl.remove();
   });

--- a/test/lost-row.js
+++ b/test/lost-row.js
@@ -38,4 +38,12 @@ describe('lost-row', function() {
       'a:last-child { margin-bottom: 0; }'
     );
   });
+
+  it('provides none rule', function() {
+    check(
+      'a { lost-row: none; }',
+      'a { width: auto; height: auto;' +
+      ' margin-bottom: 0; }'
+    );
+  });
 });


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Enhancement

**What is the current behavior (You can also link to an issue)** #263
There is currently no way to reset the `lost-row` rule. There is a way for one to reset `lost-column` so this is added to do that.  

**What is the new behavior this introduces (if any)**
`lost-row: none;` will now reset the element back to default settings.

**Does this introduce any breaking changes?**
No

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

**Other Comments**
I want to do some more testing and would love to know how this helps @kfrost89. 
