### PR TITLE
This removes the unneeded "zoom" for IE7

### DIFF
--- a/lib/lost-center.js
+++ b/lib/lost-center.js
@@ -61,11 +61,6 @@ module.exports = function lostCenterDecl(css, settings) {
     });
 
     if (lostCenterFlexbox === 'no-flex') {
-      decl.cloneBefore({
-        prop: '*zoom',
-        value: '1'
-      });
-
       newBlock(
         decl,
         ':after',

--- a/lib/lost-masonry-wrap.js
+++ b/lib/lost-masonry-wrap.js
@@ -75,11 +75,6 @@ module.exports = function lostMasonryWrapDecl(css, settings) {
     });
 
     if (lostMasonryWrapFlexbox !== 'flex') {
-      decl.cloneBefore({
-        prop: '*zoom',
-        value: '1'
-      });
-
       newBlock(
         decl,
         ':after',

--- a/lib/lost-utility.js
+++ b/lib/lost-utility.js
@@ -31,11 +31,6 @@ module.exports = function lostUtilityDecl(css, settings) {
     }
 
     if (decl.value == 'clearfix') {
-      decl.cloneBefore({
-        prop: '*zoom',
-        value: '1'
-      });
-
       newBlock(
         decl,
         ':after',

--- a/test/lost-center.js
+++ b/test/lost-center.js
@@ -6,7 +6,7 @@ describe('lost-center', function() {
   it('horizontally centers container', function() {
     check(
       'a { lost-center: 980px }',
-      'a { *zoom: 1; max-width: 980px; margin-left: auto; margin-right: auto }\n' +
+      'a { max-width: 980px; margin-left: auto; margin-right: auto }\n' +
       'a:before { content: \'\'; display: table }\n' +
       'a:after { content: \'\'; display: table; clear: both }'
     );
@@ -15,7 +15,7 @@ describe('lost-center', function() {
   it('adds 30px padding', function() {
     check(
       'a { lost-center: 980px 30px }',
-      'a { *zoom: 1; max-width: 980px; margin-left: auto; margin-right: auto; padding-left: 30px; padding-right: 30px }\n' +
+      'a { max-width: 980px; margin-left: auto; margin-right: auto; padding-left: 30px; padding-right: 30px }\n' +
       'a:before { content: \'\'; display: table }\n' +
       'a:after { content: \'\'; display: table; clear: both }'
     );

--- a/test/lost-masonry-wrap.js
+++ b/test/lost-masonry-wrap.js
@@ -14,7 +14,7 @@ describe('lost-masonry-wrap', function() {
   it('creates a non-flexbox wrapper', function() {
     check(
       'a { lost-masonry-wrap: no-flex; }',
-      'a { *zoom: 1; margin-left: -15px; margin-right: -15px; }\n' +
+      'a { margin-left: -15px; margin-right: -15px; }\n' +
       'a:before { content: \'\'; display: table; }\n' +
       'a:after { content: \'\'; display: table; clear: both; }'
     );

--- a/test/lost-utility.js
+++ b/test/lost-utility.js
@@ -15,9 +15,15 @@ describe('lost-utility', function() {
   it('applies clearfix', function() {
     check(
       'a { lost-utility: clearfix }',
-      'a { *zoom: 1 }\n' +
-      'a:before { content: \'\'; display: table }\n' +
-      'a:after { content: \'\'; display: table; clear: both }'
+      'a:before {\n' +
+      '    content: \'\';\n' +
+      '    display: table\n' +
+      '}\n' +
+      'a:after {\n' +
+      '    content: \'\';\n' +
+      '    display: table;\n' +
+      '    clear: both\n' +
+      '}'
     );
   });
 });


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
- Cleanup

**What is the current behavior (You can also link to an issue)**
- `zoom: 1` was used and it clutters the syntax

**What is the new behavior this introduces (if any)**
- `zoom: 1` has been removed

**Does this introduce any breaking changes?**
- Only if you're using IE7, which isn't supported by LostGrid. It was determined this wasn't a breaking change because of the inherent lack of support for IE7.

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [N/A] Docs have been added or updated

**Other Comments**
- As seen in #222
