### PR TITLE
Add custom color to lost-utility: edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ div {
 
 ##### Edit Mode
 
-Use `lost-utility: edit;` on `body` to visualize the entire structure of your site, or just specify the areas you're working on.
+Use `lost-utility: edit;` on `body` to visualize the entire structure of your site, or just specify the areas you're working on. You can also set custom colors of your lost-utility: edit; declaration by adding an rgb value after "edit".
 
 ```html
 <section>
@@ -299,7 +299,7 @@ section:nth-of-type(1) {
 }
 
 section:nth-of-type(2) {
-  lost-utility: edit;
+  lost-utility: edit rgb(166, 0, 0);
 }
 ```
 
@@ -475,13 +475,18 @@ Lost uses PostCSS which means to override global variables we need to use someth
 ## Property Options
 
 #### lost-utility
-A general utility toolbelt for Lost. Included are mixins that require no additional input other than being called.
+A general utility toolbelt for LostGrid. Included are mixins that require no additional input other than being called.
 
 - `edit|clearfix` - The mixin to create.
+- `edit rgb(166, 0, 0)` - Adds a custom color for the edit highlight.
 
 ```css
 section {
   lost-utility: edit;
+}
+
+div {
+  lost-utility: edit rgb(15, 150, 25);
 }
 ```
 

--- a/lib/lost-utility.js
+++ b/lib/lost-utility.js
@@ -12,6 +12,11 @@ var newBlock = require('./new-block.js');
  *   }
  *
  * @example
+ *   body {
+ *     lost-utility: edit rgb(33,44,55);
+ *   }
+ *
+ * @example
  *   .parent {
  *     lost-utility: clearfix;
  *   }
@@ -19,18 +24,41 @@ var newBlock = require('./new-block.js');
  *     lost-column: 1/2;
  *   }
  */
+
+function getColorValue(string) {
+  var color = string.split('rgb(')[1];
+  color = color.split(')')[0]
+  return color;
+}
+
 module.exports = function lostUtilityDecl(css, settings) {
   css.walkDecls('lost-utility', function(decl) {
-    if (decl.value == 'edit') {
-      newBlock(
-        decl,
-        ' *:not(input):not(textarea):not(select)',
-        ['background-color'],
-        ['rgba(0, 0, 255, 0.1)']
-      );
+
+    var utilityArray = decl.value.split(' ');
+    var utility = utilityArray[0];
+
+    if (utility == 'edit') {
+      if (utilityArray[1]) {
+        var color = getColorValue(decl.value);
+
+        newBlock(
+          decl,
+          ' *:not(input):not(textarea):not(select)',
+          ['background-color'],
+          ['rgba('+ color +', 0.1)']
+        );
+      }
+      else {
+        newBlock(
+          decl,
+          ' *:not(input):not(textarea):not(select)',
+          ['background-color'],
+          ['rgba(0, 0, 255, 0.1)']
+        );
+      }
     }
 
-    if (decl.value == 'clearfix') {
+    if (utility == 'clearfix') {
       newBlock(
         decl,
         ':after',

--- a/test/lost-utility.js
+++ b/test/lost-utility.js
@@ -12,6 +12,21 @@ describe('lost-utility', function() {
     );
   });
 
+  it('applies edit indicator with color', function() {
+    check(
+      'a { lost-utility: edit rgb(44, 55, 33) }',
+      'a *:not(input):not(textarea):not(select) {\n' +
+      '    background-color: rgba(44, 55, 33, 0.1)\n' +
+      '}'
+    ),
+    check(
+      'a { lost-utility: edit rgb(44,55,111) }',
+      'a *:not(input):not(textarea):not(select) {\n' +
+      '    background-color: rgba(44,55,111, 0.1)\n' +
+      '}'
+    );
+  });
+
   it('applies clearfix', function() {
     check(
       'a { lost-utility: clearfix }',


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Enhancement

**What is the current behavior (You can also link to an issue)**
No ability to use anything besides the default color for `lost-utility: edit;`
#127

**What is the new behavior this introduces (if any)**
Ability to use custom colors with `lost-utility: edit;`

**Does this introduce any breaking changes?**
No

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

**Other Comments**
