### PR TITLE
Fix empty columns not taking intended width

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -172,6 +172,12 @@ module.exports = function lostColumnDecl(css, settings) {
           ['float', 'margin-right', 'clear'],
           ['left', lostColumnGutter, 'none']
         );
+
+        // Add a min-height of 1px so that empty columns still take their intended width.
+        decl.cloneBefore({
+          prop: 'min-height',
+          value: '1px'
+        });
       }
 
       if (lostColumnGutter !== '0') {

--- a/test/lost-at-rule.js
+++ b/test/lost-at-rule.js
@@ -11,6 +11,7 @@ describe('lost-at-rule', function() {
       '}',
 
       'div {\n' +
+      '  min-height: 1px;\n' +
       '  width: calc(99.9% * 1/3 - (60px - 60px * 1/3));\n' +
       '}\n' +
       'div:nth-child(1n) {\n' +
@@ -64,6 +65,7 @@ describe('lost-at-rule', function() {
       '}',
 
       'div {\n' +
+      '  min-height: 1px;\n' +
       '  width: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
       '}\n' +
       'div:nth-child(1n) {\n' +
@@ -88,6 +90,7 @@ describe('lost-at-rule', function() {
       '}',
 
       'div {\n' +
+      '  min-height: 1px;\n' +
       '  width: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
       '}\n' +
       'div:nth-child(1n) {\n' +
@@ -116,6 +119,7 @@ describe('lost-at-rule', function() {
       '}',
 
       'div {\n' +
+      '  min-height: 1px;\n' +
       '  width: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
       '}\n' +
       'div:nth-child(1n) {\n' +

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -6,7 +6,7 @@ describe('lost-column', function() {
   it('provides 3 column layout', function() {
     check(
       'a { lost-column: 1/3; }',
-      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
@@ -17,7 +17,7 @@ describe('lost-column', function() {
   it('provides 2/5 column layout', function() {
     check(
       'a { lost-column: 2/5; }',
-      'a { width: calc(99.9% * 2/5 - (30px - 30px * 2/5)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 2/5 - (30px - 30px * 2/5)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(5n) { margin-right: 0; float: right; }\n' +
@@ -28,7 +28,7 @@ describe('lost-column', function() {
   it('can support custom cycle', function() {
     check(
       'a { lost-column: 2/4 2; }',
-      'a { width: calc(99.9% * 2/4 - (30px - 30px * 2/4)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 2/4 - (30px - 30px * 2/4)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(2n) { margin-right: 0; float: right; }\n' +
@@ -39,7 +39,7 @@ describe('lost-column', function() {
   it('supports no gutter', function() {
     check(
       'a { lost-column: 2/5 3 0; }',
-      'a { width: calc(99.9% * 2/5); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 2/5); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 0; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
@@ -62,7 +62,7 @@ describe('lost-column', function() {
     check(
       '@lost clearing left; \n' +
       'a { lost-column: 1/3; }',
-      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
@@ -83,7 +83,7 @@ describe('lost-column', function() {
   it('supports no-flexbox', function() {
     check(
       'a { lost-column: 2/6 3 60px no-flex; }',
-      'a { width: calc(99.9% * 2/6 - (60px - 60px * 2/6)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 2/6 - (60px - 60px * 2/6)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 60px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
@@ -95,7 +95,7 @@ describe('lost-column', function() {
     check(
       'a { lost-column: 2/6; lost-column-cycle: 6; }',
 
-      'a { width: calc(99.9% * 2/6 - (30px - 30px * 2/6)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 2/6 - (30px - 30px * 2/6)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(6n) { margin-right: 0; float: right; }\n' +
@@ -107,7 +107,7 @@ describe('lost-column', function() {
     check(
       'a { lost-column: 2/6; lost-column-gutter: 10px; }',
 
-      'a { width: calc(99.9% * 2/6 - (10px - 10px * 2/6)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 2/6 - (10px - 10px * 2/6)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 10px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(6n) { margin-right: 0; float: right; }\n' +

--- a/test/lost-global-settings.js
+++ b/test/lost-global-settings.js
@@ -7,7 +7,7 @@ describe('lost-global-settings', function() {
     check(
       '@lost clearing left; \n' +
       'a { lost-column: 1/3; }',
-      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +
@@ -16,7 +16,7 @@ describe('lost-global-settings', function() {
 
     check(
       'a { lost-column: 1/3; }',
-      'a { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
+      'a { min-height: 1px; width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 30px; clear: none; }\n' +
       'a:last-child { margin-right: 0; }\n' +
       'a:nth-child(3n) { margin-right: 0; float: right; }\n' +


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Bug fix.

**What is the current behavior (You can also link to an issue)**
Since columns are floated to left on float-based columns (flexbox columns don't suffer this issue), if a given column is empty or has a fixed positioned child, the column does not take intended width and righthand column takes over the place.

**What is the new behavior this introduces (if any)**
By adding a `min-height: 1px` rule to float-based columns, these take their intended width even if element is empty or has fixed positioned children.

**Does this introduce any breaking changes?**
Not that I know of.

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated _(docs changes seem not required)_

**Other Comments**
To reproduce, just make a couple of columns (don't add any `height` or `margin` properties to them), one after each other, but make the first column empty and add some content to the second. You'll see the second one taking over the place where the first should be. You can also try adding a child with `position: fixed` to the first column (making it virtually "empty" for CSS).
