### PR TITLE
Add node warning for v0.10 and v0.12

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 test/*.js
+lib/check-node-version.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
   - iojs
   - "0.12"
   - "0.10"
+  - "5"
+  - "6"
+  - "7"
 
 after_success:
   - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you have any questions, comments, or concerns please feel free to [open an is
 
 Lost makes use of [`calc()`](https://webdesign.tutsplus.com/tutorials/calc-grids-are-the-best-grids--cms-22902) to create stunning grids based on fractions you define without having to pass a lot of options.
 
-
+Note: After LostGrid version 8 I'm no longer going to be ensuring it works on Node 0.10 and 0.12. It still might and I will be open when it breaks but I'll be following the [Node LTS plan for Node](https://github.com/nodejs/LTS#lts-schedule). Let me know if you any questions. Thanks!
 
 
 ## Table of Contents
@@ -777,6 +777,8 @@ div {
     - Edge
   - Safari 9+
 - Automated browser testing with Selenium is coming soon. 👍
+
+Note: After LostGrid version 8 I'm no longer going to be ensuring it works on Node 0.10 and 0.12. It still might and I will be open when it breaks but I'll be following the [Node LTS plan for Node](https://github.com/nodejs/LTS#lts-schedule). Let me know if you any questions. Thanks!
 
 **[:arrow_up: back to top](#table-of-contents)**
 

--- a/lib/check-node-version.js
+++ b/lib/check-node-version.js
@@ -1,0 +1,9 @@
+module.exports = function checkNodeVersion() {
+  var nodeVersion = process.env.npm_config_node_version;
+
+  nodeVersion = nodeVersion.split('.')[0];
+
+  if (nodeVersion < 1) {
+    console.log('\033[31m', 'LostGrid is dropping support for Node versions 0.10 and 0.12 after version 8.\n If you need to retain your use of Node v0.10 v0.12 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org' ,'\x1b[0m');
+  }
+};

--- a/lib/check-node-version.js
+++ b/lib/check-node-version.js
@@ -4,6 +4,6 @@ module.exports = function checkNodeVersion() {
   nodeVersion = nodeVersion.split('.')[0];
 
   if (nodeVersion < 1) {
-    console.log('\033[31m', 'LostGrid is dropping support for Node versions 0.10 and 0.12 after version 8.\n If you need to retain your use of Node v0.10 v0.12 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org' ,'\x1b[0m');
+    console.warn('\033[31m', 'LostGrid is dropping support for Node versions 0.10 and 0.12 after version 8.\n If you need to retain your use of Node v0.10 v0.12 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org' ,'\x1b[0m');
   }
 };

--- a/lib/check-node-version.js
+++ b/lib/check-node-version.js
@@ -1,9 +1,10 @@
 module.exports = function checkNodeVersion() {
   var nodeVersion = process.env.npm_config_node_version;
 
-  nodeVersion = nodeVersion.split('.')[0];
-
-  if (nodeVersion < 1) {
-    console.warn('\033[31m', 'LostGrid is dropping support for Node versions 0.10 and 0.12 after version 8.\n If you need to retain your use of Node v0.10 v0.12 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org' ,'\x1b[0m');
+  if (nodeVersion) {
+    nodeVersion = nodeVersion.split('.')[0];
+    if (nodeVersion < 1) {
+      console.warn('\033[31m', 'LostGrid is dropping support for Node versions 0.10 and 0.12 after version 8.\n If you need to retain your use of Node v0.10 v0.12 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org' ,'\x1b[0m');
+    }
   }
 };

--- a/lib/check-node-version.js
+++ b/lib/check-node-version.js
@@ -1,10 +1,15 @@
-module.exports = function checkNodeVersion() {
-  var nodeVersion = process.env.npm_config_node_version;
+var warning = 'LostGrid is dropping support for Node versions 0.10 and 0.12 after version 8.\n If you need to retain your use of Node v0.10 v0.12 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org';
 
+module.exports = function checkNodeVersion(nodeVersion) {
+  var returnOutput = {
+    warn: false,
+    warning: warning
+  }
   if (nodeVersion) {
     nodeVersion = nodeVersion.split('.')[0];
     if (nodeVersion < 1) {
-      console.warn('\033[31m', 'LostGrid is dropping support for Node versions 0.10 and 0.12 after version 8.\n If you need to retain your use of Node v0.10 v0.12 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org' ,'\x1b[0m');
+      returnOutput.warn = true;
     }
   }
+  return returnOutput;
 };

--- a/lost.js
+++ b/lost.js
@@ -16,6 +16,9 @@ var lostMasonryWrap = require('./lib/lost-masonry-wrap');
 var lostMasonryColumn = require('./lib/lost-masonry-column');
 var checkNodeVersion = require('./lib/check-node-version');
 
+// Get the version of Node
+var nodeVersion = process.env.npm_config_node_version;
+
 // Lost At Rules and Declarations
 var libs = [
   lostAtRule,
@@ -29,8 +32,7 @@ var libs = [
   lostOffset,
   lostMove,
   lostMasonryWrap,
-  lostMasonryColumn,
-  checkNodeVersion
+  lostMasonryColumn
 ];
 
 var defaultSettings = {
@@ -43,9 +45,13 @@ var defaultSettings = {
 module.exports = postcss.plugin('lost', function lost(settings) {
   var theseSettings = assign({}, defaultSettings, settings || {});
 
+  if (checkNodeVersion(nodeVersion).warn === true) {
+    console.log(checkNodeVersion(nodeVersion).warning);
+  }
+
   return function executeLostGrid(css) {
     libs.forEach(function executeEachLostRule(lib) {
-      lib(css, theseSettings);
+      lib(css, theseSettings, nodeVersion);
     });
   };
 });

--- a/lost.js
+++ b/lost.js
@@ -14,6 +14,7 @@ var lostOffset = require('./lib/lost-offset');
 var lostMove = require('./lib/lost-move');
 var lostMasonryWrap = require('./lib/lost-masonry-wrap');
 var lostMasonryColumn = require('./lib/lost-masonry-column');
+var checkNodeVersion = require('./lib/check-node-version');
 
 // Lost At Rules and Declarations
 var libs = [
@@ -28,7 +29,8 @@ var libs = [
   lostOffset,
   lostMove,
   lostMasonryWrap,
-  lostMasonryColumn
+  lostMasonryColumn,
+  checkNodeVersion
 ];
 
 var defaultSettings = {

--- a/test/node-version.js
+++ b/test/node-version.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var expect = require('chai').expect;
+var checkNodeVersion = require('../lib/check-node-version');
+var nodeVersion = process.env.npm_config_node_version;
+
+describe('Logs Node warning if node version is 0.x', function() {
+  describe('Operates as it should with hard coded versions', function() {
+    it('logs on 0.12 and 0.10', function() {
+      expect(checkNodeVersion('0.10').warn).to.equal(true);
+      expect(checkNodeVersion('0.10').warn).to.not.equal(false);
+      expect(checkNodeVersion('0.12').warn).to.equal(true);
+      expect(checkNodeVersion('0.12').warn).to.not.equal(false);
+    });
+    it('doesn\'t log on new versions', function() {
+      expect(checkNodeVersion('6.9.1').warn).to.equal(false);
+      expect(checkNodeVersion('6.9.1').warn).to.not.equal(true);
+      expect(checkNodeVersion('7.0.0').warn).to.equal(false);
+      expect(checkNodeVersion('7.0.0').warn).to.not.equal(true);
+    });
+  });
+  describe('Operates as it should real version', function() {
+    it('logs on 0.12 and 0.10', function() {
+      if (nodeVersion.split('.')[0] < 1) {
+        console.log('Does log');
+        expect(checkNodeVersion(nodeVersion).warn).to.equal(true);
+        expect(checkNodeVersion(nodeVersion).warn).to.not.equal(false);
+      } else {
+        console.log('Doesn\'t log');
+        expect(checkNodeVersion(nodeVersion).warn).to.equal(false);
+        expect(checkNodeVersion(nodeVersion).warn).to.not.equal(true);
+      }
+    });
+  });
+});

--- a/test/node-version.js
+++ b/test/node-version.js
@@ -19,7 +19,7 @@ describe('Logs Node warning if node version is 0.x', function() {
       expect(checkNodeVersion('7.0.0').warn).to.not.equal(true);
     });
   });
-  describe('Operates as it should real version', function() {
+  describe('Operates as it should with \"real\" Node version', function() {
     it('logs on 0.12 and 0.10', function() {
       if (nodeVersion.split('.')[0] < 1) {
         console.log('Does log');


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Addition of check for "older" versions of Node

**What is the current behavior (You can also link to an issue)**
No warning when using old versions of Node

**What is the new behavior this introduces (if any)**
Warning when using Node v0.10 or v0.12.

**Does this introduce any breaking changes?**
It shouldn't

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [x] Docs have been added or updated
- [x] Write blog post


**Other Comments**
I want to make sure this wouldn't break anyone's build process with the addition of the log. ...hmm. Need to do some testing and asking around.