### PR TITLE
Update README, putting params in order

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,10 +557,10 @@ Align nested elements. Apply this to a parent container.
 Creates a column that is a fraction of the size of its containing element's width with a gutter.
 
 - `fraction` - This is a simple fraction of the containing element's width.
+- `cycle` - Lost works by assigning a margin-right to all elements except the last in the row. It does this by default by using the denominator of the fraction you pick. To override the default use this param., e.g.: .foo { lost-column: 2/4 2; }
 - `gutter` - The margin on the right side of the element used to create a gutter. Typically this is left alone and settings.gutter will be used, but you can override it here if you want
 certain elements to have a particularly large or small gutter (pass 0 for no gutter at all).
   - When specifying the gutter, you need to also specify the cycle. [see issue 181](https://github.com/peterramsing/lost/issues/181)
-- `cycle` - Lost works by assigning a margin-right to all elements except the last in the row. It does this by default by using the denominator of the fraction you pick. To override the default use this param., e.g.: .foo { lost-column: 2/4 2; }
 - `flex|no-flex` - Determines whether this element should use Flexbox or not.
 - `none` - Resets the column (back to browser defaults)
 


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**

Documentation tweak

**What is the current behavior (You can also link to an issue)**


**What is the new behavior this introduces (if any)**


**Does this introduce any breaking changes?**


**Does the PR fulfill these requirements?**
- [ ] Tests for the changes have been added
- [X] Docs have been added or updated


**Other Comments**

Rearranged bullet points to be explained in the correct order.

lost-column: <fraction> <cycle> <gutter> <flex>

Parameters should thus be explained in this order. 

Literally just swapped the gutter and cycle bullet points