### PR TITLE
Lost move retain gutter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 test/*.js
-lib/check-node-version.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 First off, thanks for wanting to help!
 
-To help keep LostGrid an organized codebase we use ESLint to organize the code. This will be added to the build process in coming versions. Until then please abide by the current ESLint configuration. You can test this by running `./node_modules/.bin/eslint ./lib/*.js lost.js` in your codebase before committing.
+To help keep LostGrid an organized codebase we use ESLint to organize the code. This will be added to the build process in coming versions. Until then please abide by the current ESLint configuration. You can test this by running `npm run lint` in your codebase before committing.
 
 Thanks, and don't hesitate to reach out if you have any questions!
 

--- a/lib/check-node-version.js
+++ b/lib/check-node-version.js
@@ -4,7 +4,7 @@ module.exports = function checkNodeVersion(nodeVersion) {
   var returnOutput = {
     warn: false,
     warning: warning
-  }
+  };
   if (nodeVersion) {
     nodeVersion = nodeVersion.split('.')[0];
     if (nodeVersion < 1) {

--- a/lib/lost-move.js
+++ b/lib/lost-move.js
@@ -36,10 +36,6 @@ module.exports = function lostMoveDecl(css, settings) {
       lostMoveDirection = declArr[1];
     }
 
-    if (declArr[2] !== undefined && declArr[2].search(/^\d/) !== -1) {
-      lostMoveGutter = declArr[2];
-    }
-
     decl.parent.nodes.forEach(function lostMoveRounderFunction(declaration) {
       if (declaration.prop === 'lost-move-rounder') {
         lostMoveRounder = declaration.value;
@@ -71,6 +67,10 @@ module.exports = function lostMoveDecl(css, settings) {
         lostMoveGutter = declaration.value;
       }
     });
+
+    if (declArr[2] !== undefined && declArr[2].search(/^\d/) !== -1) {
+      lostMoveGutter = declArr[2];
+    }
 
     decl.parent.nodes.forEach(function lostMoveDirectionFunction(declaration) {
       if (declaration.prop === 'lost-move-direction') {

--- a/lib/lost-move.js
+++ b/lib/lost-move.js
@@ -55,6 +55,9 @@ module.exports = function lostMoveDecl(css, settings) {
           lostMoveGutter = columnArray[2];
         }
       }
+      if (declaration.prop === 'lost-column-gutter') {
+        lostMoveGutter = declaration.value;
+      }
     });
 
     decl.parent.nodes.forEach(function lostMoveDirectionFunction(declaration) {

--- a/lib/lost-move.js
+++ b/lib/lost-move.js
@@ -60,6 +60,18 @@ module.exports = function lostMoveDecl(css, settings) {
       }
     });
 
+    decl.parent.nodes.forEach( (declaration) => {
+      if (declaration.prop === 'lost-row') {
+        let rowArray = declaration.value.split(' ');
+        if (rowArray[1]) {
+          lostMoveGutter = rowArray[1];
+        }
+      }
+      if (declaration.prop === 'lost-row-gutter') {
+        lostMoveGutter = declaration.value;
+      }
+    });
+
     decl.parent.nodes.forEach(function lostMoveDirectionFunction(declaration) {
       if (declaration.prop === 'lost-move-direction') {
         lostMoveDirection = declaration.value;

--- a/lib/lost-move.js
+++ b/lib/lost-move.js
@@ -48,6 +48,15 @@ module.exports = function lostMoveDecl(css, settings) {
       }
     });
 
+    decl.parent.nodes.forEach( (declaration) => {
+      if (declaration.prop === 'lost-column') {
+        let columnArray = declaration.value.split(' ');
+        if (columnArray[2]) {
+          lostMoveGutter = columnArray[2];
+        }
+      }
+    });
+
     decl.parent.nodes.forEach(function lostMoveDirectionFunction(declaration) {
       if (declaration.prop === 'lost-move-direction') {
         lostMoveDirection = declaration.value;

--- a/lost.js
+++ b/lost.js
@@ -24,6 +24,7 @@ var nodeVersion = process.env.npm_config_node_version;
 var libs = [
   lostAtRule,
   lgGutter,
+  lostMove,
   lostUtility,
   lostFlexContainer,
   lostCenter,
@@ -32,7 +33,6 @@ var libs = [
   lostRow,
   lostWaffle,
   lostOffset,
-  lostMove,
   lostMasonryWrap,
   lostMasonryColumn
 ];

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "scripts": {
     "test": "istanbul cover node_modules/mocha/bin/_mocha -- test/*.js",
-    "lint": "node_modules/.bin/eslint lib/*.js"
+    "lint": "node_modules/.bin/eslint lib/*.js lost.js"
   }
 }

--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -67,6 +67,14 @@ describe('lost-move', function() {
     );
   });
 
+  it(`doesn't override the gutter set by lost-move`, () => {
+    check(
+      `a { lost-row: 1/3; lost-move: -1/3 column 70px; lost-row-gutter: 50px; }`,
+      `a { width: 100%; height: calc(99.9% * 1/3 - (50px - 50px * 1/3)); margin-bottom: 50px; position: relative; top: calc(99.9% * -1/3 - (70px - 70px * -1/3) + 70px); }\n`+
+      `a:last-child { margin-bottom: 0; }`
+    )
+  });
+
   it('supports custom gutter', function() {
     check(
       'a { lost-move: 1/2 row 60px; }',

--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -53,6 +53,18 @@ describe('lost-move', function() {
       `a:nth-child(3n + 1) { clear: both; }`
     );
   });
+
+  it('retains the lost-row gutter', () => {
+    check(
+      `a { lost-row: 1/3 50px; lost-move: -1/3 column; }`,
+      `a { width: 100%; height: calc(99.9% * 1/3 - (50px - 50px * 1/3)); margin-bottom: 50px; position: relative; top: calc(99.9% * -1/3 - (50px - 50px * -1/3) + 50px); }\n`+
+      `a:last-child { margin-bottom: 0; }`
+    );
+    check(
+      `a { lost-row: 1/3; lost-move: -1/3 column; lost-row-gutter: 50px; }`,
+      `a { width: 100%; height: calc(99.9% * 1/3 - (50px - 50px * 1/3)); margin-bottom: 50px; position: relative; top: calc(99.9% * -1/3 - (50px - 50px * -1/3) + 50px); }\n`+
+      `a:last-child { margin-bottom: 0; }`
+    );
   });
 
   it('supports custom gutter', function() {

--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -44,6 +44,15 @@ describe('lost-move', function() {
       `a:nth-child(3n) { margin-right: 0; float: right; }\n`+
       `a:nth-child(3n + 1) { clear: both; }`
     );
+    check(
+      `a { lost-column: 1/3; lost-move: -1/3 row; lost-column-gutter: 50px; }`,
+      `a { width: calc(99.9% * 1/3 - (50px - 50px * 1/3)); position: relative; left: calc(99.9% * -1/3 - (50px - 50px * -1/3) + 50px); }\n`+
+      `a:nth-child(1n) { float: left; margin-right: 50px; clear: none; }\n`+
+      `a:last-child { margin-right: 0; }\n`+
+      `a:nth-child(3n) { margin-right: 0; float: right; }\n`+
+      `a:nth-child(3n + 1) { clear: both; }`
+    );
+  });
   });
 
   it('supports custom gutter', function() {

--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -35,6 +35,17 @@ describe('lost-move', function() {
     );
   });
 
+  it('retains the lost-column gutter', () => {
+    check(
+      `a { lost-column: 1/3 3 50px; lost-move: -1/3 row; }`,
+      `a { width: calc(99.9% * 1/3 - (50px - 50px * 1/3)); position: relative; left: calc(99.9% * -1/3 - (50px - 50px * -1/3) + 50px); }\n`+
+      `a:nth-child(1n) { float: left; margin-right: 50px; clear: none; }\n`+
+      `a:last-child { margin-right: 0; }\n`+
+      `a:nth-child(3n) { margin-right: 0; float: right; }\n`+
+      `a:nth-child(3n + 1) { clear: both; }`
+    );
+  });
+
   it('supports custom gutter', function() {
     check(
       'a { lost-move: 1/2 row 60px; }',

--- a/test/lost-move.js
+++ b/test/lost-move.js
@@ -72,7 +72,12 @@ describe('lost-move', function() {
       `a { lost-row: 1/3; lost-move: -1/3 column 70px; lost-row-gutter: 50px; }`,
       `a { width: 100%; height: calc(99.9% * 1/3 - (50px - 50px * 1/3)); margin-bottom: 50px; position: relative; top: calc(99.9% * -1/3 - (70px - 70px * -1/3) + 70px); }\n`+
       `a:last-child { margin-bottom: 0; }`
-    )
+    );
+    check(
+      `a { lost-row: 1/3; lost-move: -1/3 column; lost-move-gutter: 70px; lost-row-gutter: 50px; }`,
+      `a { width: 100%; height: calc(99.9% * 1/3 - (50px - 50px * 1/3)); margin-bottom: 50px; position: relative; top: calc(99.9% * -1/3 - (70px - 70px * -1/3) + 70px); }\n`+
+      `a:last-child { margin-bottom: 0; }`
+    );
   });
 
   it('supports custom gutter', function() {


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Bugfix, lint cleanup

**What is the current behavior (You can also link to an issue)**
* `lost-gutter` would not retain the gutter of `lost-row` or `lost-column`. (#195)
* check-node-version was ignored by lint

**What is the new behavior this introduces (if any)**
`lost-gutter` not retains the gutter from column or row.
* check-node-version now not ignored
* lint updates

**Does this introduce any breaking changes?**
Sort of... any uses of lost-move that had column or row gutters specified will now have updated gutters.

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [x] Docs have been added or updated
