### PR TITLE
Removes inline docs that are not updated/current

### DIFF
--- a/lib/lost-align.js
+++ b/lib/lost-align.js
@@ -1,27 +1,5 @@
 var newBlock = require('./new-block.js');
 
-/**
- * lost-align: Align nested elements. Apply this to a parent container.
- *
- * @param {string} [reset|horizontal|vertical|top-left|top-center|top|
- * top-right|middle-left|left|middle-center|center|middle-right|right|
- * bottom-left|bottom-center|bottom|bottom-right] - The position the nested
- *   element takes relative to the containing element.
- *
- * @param {string} [flex|no-flex] - Determines whether this element should
- *   use Flexbox or not.
- *
- * @example
- *   .parent {
- *     lost-align: right;
- *     width: 600px;
- *     height: 400px;
- *   }
- *   .child {
- *     width: 300px;
- *     height: 150px;
- *   }
- */
 module.exports = function lostAlign(css, settings) {
   css.walkDecls('lost-align', function alignDirectionFunction(decl) {
     var declArr = [];

--- a/lib/lost-at-rule.js
+++ b/lib/lost-at-rule.js
@@ -1,13 +1,3 @@
-/**
-* Override global settings from at-rules set in stylesheet.
-*
-* @example
-*   @lost gutter 60px;
-*
-*   div {
-*     lost-column: 1/3;
-*   }
-*/
 module.exports = function lostAtRule(css, Settings) {
   css.walkAtRules('lost', function lostAtRuleFunction(Rule) {
     var rule = Rule;

--- a/lib/lost-center.js
+++ b/lib/lost-center.js
@@ -1,27 +1,5 @@
 var newBlock = require('./new-block.js');
 
-/**
- * lost-center: Horizontally center a container element and apply padding
- * to it.
- *
- * @param {length} [max-width] - A max-width to assign. Can be any unit.
- *
- * @param {length} [padding] - Padding on the left and right of the element.
- *   Can be any unit.
- *
- * @param {string} [flex|no-flex] - Determines whether this element should
- *   use Flexbox or not.
- *
- * @example
- *   section {
- *     lost-center: 980px;
- *   }
- *
- * @example
- *   section {
- *     lost-center: 1140px 30px flex;
- *   }
- */
 module.exports = function lostCenterDecl(css, settings) {
   css.walkDecls('lost-center', function lostCenterFunction(decl) {
     var declArr = [];

--- a/lib/lost-center.js
+++ b/lib/lost-center.js
@@ -2,7 +2,7 @@ var newBlock = require('./new-block.js');
 
 var lgLogic = require('./_lg-logic');
 
-module.exports = function lostCenterDecl(css, settings) {
+module.exports = function lostCenterDecl(css, settings, result) {
   css.walkDecls('lost-center', function lostCenterFunction(decl) {
     var declArr = [];
     var lostCenterPadding;

--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -1,39 +1,6 @@
 var newBlock = require('./new-block.js');
 
 var lgLogic = require('./_lg-logic');
-
-/**
- * lost-column: Creates a column that is a fraction of the size of its
- * containing element's width with a gutter.
- *
- * @param {string} [fraction] - This is a simple fraction of the containing
- *   element's width.
- *
- * @param {integer} [cycle] - Lost works by assigning a margin-right to all
- *   elements except the last in the row. If settings.cycle is set to auto
- *   it will do this by default by using the denominator of the fraction you
- *   pick. To override the default use this param.,
- *   e.g.: .foo { lost-column: 2/4 2; }
- *
- * @param {length} [gutter] - The margin on the right side of the element
- *   used to create a gutter. Typically this is left alone and
- *   settings.gutter will be used, but you can override it here if you want
- *   certain elements to have a particularly large or small gutter (pass 0
- *   for no gutter at all).
- *
- * @param {string} [flex|no-flex] - Determines whether this element should
- *   use Flexbox or not.
- *
- * @example
- *   div {
- *     lost-column: 1/3;
- *   }
- *
- * @example
- *   div {
- *     lost-column: 2/6 3 60px flex;
- *   }
- */
 module.exports = function lostColumnDecl(css, settings, result) {
   css.walkDecls('lost-column', function lostColumnFunction(decl) {
     var declArr = [];

--- a/lib/lost-flex-container.js
+++ b/lib/lost-flex-container.js
@@ -1,18 +1,3 @@
-/**
- * lost-flex-container: Creates a Flexbox container.
- *
- * @param {string} [row|column] - The flex-direction the container should
- *   create. This is typically opposite to the element you're creating so a
- *   row would need `lost-flex-container: column;`.
- *
- * @example
- *   section {
- *     lost-flex-container: row;
- *   }
- *   div {
- *     lost-column: 1/2 flex;
- *   }
- */
 module.exports = function lostFlexContainerDecl(css) {
   css.walkDecls('lost-flex-container', function lostFlexContainerFunction(decl) {
     decl.cloneBefore({

--- a/lib/lost-masonry-column.js
+++ b/lib/lost-masonry-column.js
@@ -1,23 +1,3 @@
-/**
- * lost-masonry-column: Creates a column for working with JS masonry
- * libraries like Isotope. Assigns a margin to each side of the element.
- *
- * @param {length} [gutter] - How large the gutter involved is, typically
- *   this won't be adjusted and will inherit settings.gutter, but it's made
- *   available if you want your masonry grid to have a special gutter, it
- *   should match your masonry-row's gutter.
- *
- * @param {string} [flex|no-flex] - Determines whether this element should
- *   use Flexbox or not.
- *
- * @example
- *   section {
- *     lost-masonry-wrap: flex 60px;
- *   }
- *   div {
- *     lost-masonry-column: 1/3 60px flex;
- *   }
- */
 module.exports = function lostMasonryColumnDecl(css, settings) {
   css.walkDecls('lost-masonry-column', function lostMasonryColumnFunction(decl) {
     var declArr = [];

--- a/lib/lost-masonry-wrap.js
+++ b/lib/lost-masonry-wrap.js
@@ -1,26 +1,5 @@
 var newBlock = require('./new-block.js');
 
-/**
- * lost-masonry-wrap: Creates a wrapping element for working with JS Masonry
- * libraries like Isotope. Assigns a negative margin on each side of this
- * wrapping element.
- *
- * @param {string} [flex|no-flex] - Determines whether this element should
- *   use Flexbox or not.
- *
- * @param {length} [gutter] - How large the gutter involved is, typically
- *   this won't be adjusted and will inherit settings.gutter, but it's made
- *   available if you want your masonry grid to have a special gutter, it
- *   should match your masonry-column's gutter.
- *
- * @example
- *   section {
- *     lost-masonry-wrap: no-flex;
- *   }
- *   div {
- *     lost-masonry-column: 1/3;
- *   }
- */
 module.exports = function lostMasonryWrapDecl(css, settings) {
   css.walkDecls('lost-masonry-wrap', function lostMasonryWrapDeclFunction(decl) {
     var declArr = [];

--- a/lib/lost-move.js
+++ b/lib/lost-move.js
@@ -1,26 +1,3 @@
-/**
- * lost-move: Source ordering. Shift elements left, right, up, or down, by
- * their left or top position by passing a positive or negative fraction.
- *
- * @param {string} [fraction] - Fraction of the container to be shifted.
- *
- * @param {string} [row|column] - Direction the grid is going. Should be the
- *   opposite of the column or row it's being used on.
- *
- * @param {length} [gutter] - Adjust the size of the gutter for this
- *   movement. Should match the element's gutter.
- *
- * @example
- *   div {
- *     lost-column: 1/2;
- *   }
- *   div:first-child {
- *     lost-move: 1/2;
- *   }
- *   div:last-child {
- *     lost-move: -1/2;
- *   }
- */
 module.exports = function lostMoveDecl(css, settings) {
   css.walkDecls('lost-move', function lostMoveDeclFunction(decl) {
     var declArr = [];

--- a/lib/lost-offset.js
+++ b/lib/lost-offset.js
@@ -1,26 +1,3 @@
-/**
- * lost-offset: Margin to the left, right, bottom, or top, of an element
- * depending on if the fraction passed is positive or negative. It works for
- * both horizontal and vertical grids but not both.
- *
- * @param {string} [fraction] - Fraction of the container to be offset.
- *
- * @param {string} [row|column] - Direction the grid is going. Should be the
- *   opposite of the column or row it's being used on. Defaults to row.
- *
- * @param {length} [gutter] - How large the gutter involved is, typically
- *   this won't be adjusted, but if you have set the elements for that
- *   container to have different gutters than default, you will need to
- *   match that gutter here as well.
- *
- * @example
- *   .two-elements {
- *     lost-column: 1/3;
- *   }
- *   .two-elements:first-child {
- *     lost-offset: 1/3;
- *   }
- */
 module.exports = function lostOffsetDecl(css, settings) {
   css.walkDecls('lost-offset', function lostOffsetDeclFunction(decl) {
     var declArr = [];

--- a/lib/lost-row.js
+++ b/lib/lost-row.js
@@ -2,32 +2,6 @@ var newBlock = require('./new-block.js');
 
 var lgLogic = require('./_lg-logic');
 
-/**
- * lost-row: Creates a row that is a fraction of the size of its containing
- * element's height with a gutter.
- *
- * @param {string} [fraction] - This is a simple fraction of the containing
- *   element's height.
- *
- * @param {length} [gutter] - The margin on the bottom of the element used
- *   to create a gutter. Typically this is left alone and settings.gutter
- *   will be used, but you can override it here if you want certain elements
- *   to have a particularly large or small gutter (pass 0 for no gutter at
- *   all).
- *
- * @param {string} [flex|no-flex] - Determines whether this element should
- *   use Flexbox or not.
- *
- * @param {string} [none] - Resets to a standard browser default.
- *
- * @example
- *   section {
- *     height: 100%;
- *   }
- *   div {
- *     lost-row: 1/3;
- *   }
- */
 module.exports = function lostRowDecl(css, settings, result) {
   css.walkDecls('lost-row', function lostRowDeclFunction(decl) {
     var declArr = [];

--- a/lib/lost-utility.js
+++ b/lib/lost-utility.js
@@ -1,30 +1,5 @@
 var newBlock = require('./new-block.js');
 
-/**
- * lost-utility: A general utility toolbelt for Lost. Included are mixins
- * that require no additional input other than being called.
- *
- * @param {string} [edit|clearfix] - The mixin to create.
- *
- * @example
- *   body {
- *     lost-utility: edit;
- *   }
- *
- * @example
- *   body {
- *     lost-utility: edit rgb(33,44,55);
- *   }
- *
- * @example
- *   .parent {
- *     lost-utility: clearfix;
- *   }
- *   .child {
- *     lost-column: 1/2;
- *   }
- */
-
 function getColorValue(string) {
   var color = string.split('rgb(')[1];
   color = color.split(')')[0];

--- a/lib/lost-waffle.js
+++ b/lib/lost-waffle.js
@@ -2,39 +2,6 @@ var newBlock = require('./new-block.js');
 
 var lgLogic = require('./_lg-logic');
 
-/**
- * lost-waffle: Creates a block that is a fraction of the size of its
- * containing element's width AND height with a gutter on the right
- * and bottom.
- *
- * @param {string} [fraction] - This is a simple fraction of the containing
- *   element's width and height.
- *
- * @param {integer} [cycle] - Lost works by assigning a margin-right/bottom
- *   to all elements except the last row (no margin-bottom) and the last
- *   column (no margin-right). It does this by default by using the
- *   denominator of the fraction you pick. To override this default use this
- *   param., e.g.: .foo { lost-waffle: 2/4 2; }
- *
- * @param {length} [gutter] - The margin on the right and bottom side of the
- *   element used to create a gutter. Typically this is left alone and the
- *   global $gutter will be used, but you can override it here if you want
- *   certain elements to have a particularly large or small gutter (pass 0
- *   for no gutter at all).
- *
- * @param {string} [float-right] - Tells whether or not the cycle should float right
- *
- * @param {string} [flex|no-flex] - Determines whether this element should
- *   use Flexbox or not.
- *
- * @example
- *   section {
- *     height: 100%;
- *   }
- *   div {
- *     lost-waffle: 1/3;
- *   }
- */
 module.exports = function lostWaffleDecl(css, settings, result) {
   css.walkDecls('lost-waffle', function lostWaffleDeclFunction(decl) {
     var declArr = [];


### PR DESCRIPTION
I've been pondering this for a while. As I've been working on more and more projects I've learned that the more documentation that is written the more that needs to be maintained. **I think documentation is great!** This documentation is just a duplicate of that documentation that is on the site, though–and I have not been maintaining it well.

Now, if someone wanted to work on having the inline docs create external docs, I'm all ears. There are people who are much better at that than I so I'm more than happy to receive outside input, here.

I'm creating a pull request for this to get some outside input on this and if there are any immediate objections to this.  **because these are not maintained something needs to happen as they are already causing me confusion and I've heard from others similarly.** I don't want to maintain two sets of docs, though...