### PR TITLE
add nyc and codecov for coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pids
 lib-cov
 
 # Coverage directory used by tools like istanbul
+.nyc_output
 coverage
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
   "homepage": "http://lostgrid.org",
   "devDependencies": {
     "chai": "^3.5",
+    "codecov": "^2.1.0",
     "eslint": "^3.16",
-    "istanbul": "^0.4",
-    "mocha": "^3.2"
+    "mocha": "^3.2",
+    "nyc": "^10.3.2"
   },
   "scripts": {
-    "test": "istanbul cover node_modules/mocha/bin/_mocha -- test/*.js",
-    "lint": "node_modules/.bin/eslint lib/*.js lost.js"
+    "test": "nyc mocha && codecov",
+    "lint": "eslint --ignore-path .gitignore ."
   }
 }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    'env': {
+        'mocha': true,
+    },
+};

--- a/test/lg-gutter.js
+++ b/test/lg-gutter.js
@@ -1,36 +1,34 @@
-'use strict'
-
-var expect = require('chai').expect;
+'use strict';
 
 var check = require('./check');
 
 describe('lost-gutter', () => {
   it('replaces $lost-gutter with global', () => {
     check(
-      `div { padding: $lost-gutter; }`,
-      `div { padding: 30px; }`
+      'div { padding: $lost-gutter; }',
+      'div { padding: 30px; }'
     );
     check(
-      `div { margin: 25px $lost-gutter; }`,
-      `div { margin: 25px 30px; }`
+      'div { margin: 25px $lost-gutter; }',
+      'div { margin: 25px 30px; }'
     );
     check(
-      `div { margin: 25px $lost-gutter $lost-gutter; }`,
-      `div { margin: 25px 30px 30px; }`
+      'div { margin: 25px $lost-gutter $lost-gutter; }',
+      'div { margin: 25px 30px 30px; }'
     );
     check(
-      `div { padding: $lost-gutter; lost-column: 1/3 3 40px; }`,
-      `div { padding: 30px; width: calc(99.9% * 1/3 - (40px - 40px * 1/3)); }\n`+
-      `div:nth-child(1n) { float: left; margin-right: 40px; clear: none; }\n`+
-      `div:last-child { margin-right: 0; }\n`+
-      `div:nth-child(3n) { margin-right: 0; float: right; }\n`+
-      `div:nth-child(3n + 1) { clear: both; }`
+      'div { padding: $lost-gutter; lost-column: 1/3 3 40px; }',
+      'div { padding: 30px; width: calc(99.9% * 1/3 - (40px - 40px * 1/3)); }\n'+
+      'div:nth-child(1n) { float: left; margin-right: 40px; clear: none; }\n'+
+      'div:last-child { margin-right: 0; }\n'+
+      'div:nth-child(3n) { margin-right: 0; float: right; }\n'+
+      'div:nth-child(3n + 1) { clear: both; }'
     );
   });
   it('replaces $lost-gutter with global when global is not default', () => {
     check(
-      `@lost gutter 40px; div { padding: $lost-gutter; }`,
-      `div { padding: 40px; }`
+      '@lost gutter 40px; div { padding: $lost-gutter; }',
+      'div { padding: 40px; }'
     );
   });
 });
@@ -39,94 +37,94 @@ describe('lost-gutter', () => {
 describe('lost-gutter-local', () => {
   it('replaces $lost-gutter-local', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-column: 1/3; lost-column-gutter: 50px; }`,
-      `div { padding: 50px; width: calc(99.9% * 1/3 - (50px - 50px * 1/3)); }\n`+
-      `div:nth-child(1n) { float: left; margin-right: 50px; clear: none; }\n`+
-      `div:last-child { margin-right: 0; }\n`+
-      `div:nth-child(3n) { margin-right: 0; float: right; }\n`+
-      `div:nth-child(3n + 1) { clear: both; }`
+      'div { padding: $lost-gutter-local; lost-column: 1/3; lost-column-gutter: 50px; }',
+      'div { padding: 50px; width: calc(99.9% * 1/3 - (50px - 50px * 1/3)); }\n'+
+      'div:nth-child(1n) { float: left; margin-right: 50px; clear: none; }\n'+
+      'div:last-child { margin-right: 0; }\n'+
+      'div:nth-child(3n) { margin-right: 0; float: right; }\n'+
+      'div:nth-child(3n + 1) { clear: both; }'
     );
     check(
-      `div { padding: $lost-gutter-local; lost-column: 1/3; lost-column-gutter: 0; }`,
-      `div { padding: 0; width: calc(99.9% * 1/3); }\n`+
-      `div:nth-child(1n) { float: left; margin-right: 0; clear: none; }\n`+
-      `div:last-child { margin-right: 0; }\n`+
-      `div:nth-child(3n) { margin-right: 0; float: right; }\n`+
-      `div:nth-child(3n + 1) { clear: both; }`
+      'div { padding: $lost-gutter-local; lost-column: 1/3; lost-column-gutter: 0; }',
+      'div { padding: 0; width: calc(99.9% * 1/3); }\n'+
+      'div:nth-child(1n) { float: left; margin-right: 0; clear: none; }\n'+
+      'div:last-child { margin-right: 0; }\n'+
+      'div:nth-child(3n) { margin-right: 0; float: right; }\n'+
+      'div:nth-child(3n + 1) { clear: both; }'
     );
   });
   it('works on shortcut lost-column', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-column: 1/3 3 70px;}`,
-      `div { padding: 70px; width: calc(99.9% * 1/3 - (70px - 70px * 1/3));}\n`+
-      `div:nth-child(1n) { float: left; margin-right: 70px; clear: none;}\n`+
-      `div:last-child { margin-right: 0;}\n`+
-      `div:nth-child(3n) { margin-right: 0; float: right;}\n`+
-      `div:nth-child(3n + 1) { clear: both;}`
+      'div { padding: $lost-gutter-local; lost-column: 1/3 3 70px;}',
+      'div { padding: 70px; width: calc(99.9% * 1/3 - (70px - 70px * 1/3));}\n'+
+      'div:nth-child(1n) { float: left; margin-right: 70px; clear: none;}\n'+
+      'div:last-child { margin-right: 0;}\n'+
+      'div:nth-child(3n) { margin-right: 0; float: right;}\n'+
+      'div:nth-child(3n + 1) { clear: both;}'
     );
   });
   it('works on shortcut lost-waffle', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-waffle: 1/3 3 20px;}`,
-      `div { padding: 20px; width: calc(99.9% * 1/3 - (20px - 20px * 1/3)); height: calc(99.9% * 1/3 - (20px - 20px * 1/3));}\n`+
-      `div:nth-child(1n) { float: left; margin-right: 20px; margin-bottom: 20px; clear: none;}\n` +
-      `div:last-child { margin-right: 0; margin-bottom: 0;}\n` +
-      `div:nth-child(3n) { margin-right: 0;}\n` +
-      `div:nth-child(3n + 1) { clear: both;}\n` +
-      `div:nth-last-child(-n + 3) { margin-bottom: 0;}`
+      'div { padding: $lost-gutter-local; lost-waffle: 1/3 3 20px;}',
+      'div { padding: 20px; width: calc(99.9% * 1/3 - (20px - 20px * 1/3)); height: calc(99.9% * 1/3 - (20px - 20px * 1/3));}\n'+
+      'div:nth-child(1n) { float: left; margin-right: 20px; margin-bottom: 20px; clear: none;}\n' +
+      'div:last-child { margin-right: 0; margin-bottom: 0;}\n' +
+      'div:nth-child(3n) { margin-right: 0;}\n' +
+      'div:nth-child(3n + 1) { clear: both;}\n' +
+      'div:nth-last-child(-n + 3) { margin-bottom: 0;}'
     );
   });
   it('works on shortcut lost-offset', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-offset: 1/3 3 100px;}`,
-      `div { padding: 100px; margin-left: calc(99.9% * (-1/3 * -1) - (100px - 100px * (-1/3 * -1)) + 100px) !important;}`
+      'div { padding: $lost-gutter-local; lost-offset: 1/3 3 100px;}',
+      'div { padding: 100px; margin-left: calc(99.9% * (-1/3 * -1) - (100px - 100px * (-1/3 * -1)) + 100px) !important;}'
     );
   });
   it('works on shortcut lost-center', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-center: 400px 60px;}`,
-      `div { padding: 60px; max-width: 400px; margin-left: auto; margin-right: auto; padding-left: 60px; padding-right: 60px;}\n` +
-      `div:before { content: ''; display: table;}\n` +
-      `div:after { content: ''; display: table; clear: both;}`
+      'div { padding: $lost-gutter-local; lost-center: 400px 60px;}',
+      'div { padding: 60px; max-width: 400px; margin-left: auto; margin-right: auto; padding-left: 60px; padding-right: 60px;}\n' +
+      'div:before { content: \'\'; display: table;}\n' +
+      'div:after { content: \'\'; display: table; clear: both;}'
     );
   });
   it('works on shortcut lost-masonry-wrap', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-masonry-wrap: flex 60px;}`,
-      `div { padding: 60px; display: flex; flex-flow: row wrap; margin-left: -30px; margin-right: -30px;}`
+      'div { padding: $lost-gutter-local; lost-masonry-wrap: flex 60px;}',
+      'div { padding: 60px; display: flex; flex-flow: row wrap; margin-left: -30px; margin-right: -30px;}'
     );
   });
   it('works on shortcut lost-masonry-column', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-masonry-column: 1/3 15px;}`,
-      `div { padding: 15px; float: left; width: calc(99.9% * 1/3 - 15px); margin-left: 7.5px; margin-right: 7.5px;}`
+      'div { padding: $lost-gutter-local; lost-masonry-column: 1/3 15px;}',
+      'div { padding: 15px; float: left; width: calc(99.9% * 1/3 - 15px); margin-left: 7.5px; margin-right: 7.5px;}'
     );
   });
   it('works on shortcut lost-row', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-row: 1/3 70px;}`,
-      `div { padding: 70px; width: 100%; height: calc(99.9% * 1/3 - (70px - 70px * 1/3)); margin-bottom: 70px;}\n` +
-      `div:last-child { margin-bottom: 0;}`
+      'div { padding: $lost-gutter-local; lost-row: 1/3 70px;}',
+      'div { padding: 70px; width: 100%; height: calc(99.9% * 1/3 - (70px - 70px * 1/3)); margin-bottom: 70px;}\n' +
+      'div:last-child { margin-bottom: 0;}'
     );
   });
   it('takes global if no local one is given', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-column: 1/3;}`,
-      `div { padding: 30px; width: calc(99.9% * 1/3 - (30px - 30px * 1/3));}\n` +
-      `div:nth-child(1n) { float: left; margin-right: 30px; clear: none;}\n` +
-      `div:last-child { margin-right: 0;}\n` +
-      `div:nth-child(3n) { margin-right: 0; float: right;}\n` +
-      `div:nth-child(3n + 1) { clear: both;}`
+      'div { padding: $lost-gutter-local; lost-column: 1/3;}',
+      'div { padding: 30px; width: calc(99.9% * 1/3 - (30px - 30px * 1/3));}\n' +
+      'div:nth-child(1n) { float: left; margin-right: 30px; clear: none;}\n' +
+      'div:last-child { margin-right: 0;}\n' +
+      'div:nth-child(3n) { margin-right: 0; float: right;}\n' +
+      'div:nth-child(3n + 1) { clear: both;}'
     );
   });
   it('allows for multiple uses of the variable', () => {
     check(
-      `div { padding: $lost-gutter-local; lost-column: 1/3 3 20px; margin-top: $lost-gutter-local;}`,
-      `div { padding: 20px; width: calc(99.9% * 1/3 - (20px - 20px * 1/3)); margin-top: 20px;}\n` +
-      `div:nth-child(1n) { float: left; margin-right: 20px; clear: none;}\n` +
-      `div:last-child { margin-right: 0;}\n` +
-      `div:nth-child(3n) { margin-right: 0; float: right;}\n` +
-      `div:nth-child(3n + 1) { clear: both;}`
+      'div { padding: $lost-gutter-local; lost-column: 1/3 3 20px; margin-top: $lost-gutter-local;}',
+      'div { padding: 20px; width: calc(99.9% * 1/3 - (20px - 20px * 1/3)); margin-top: 20px;}\n' +
+      'div:nth-child(1n) { float: left; margin-right: 20px; clear: none;}\n' +
+      'div:last-child { margin-right: 0;}\n' +
+      'div:nth-child(3n) { margin-right: 0; float: right;}\n' +
+      'div:nth-child(3n + 1) { clear: both;}'
     );
   });
 });

--- a/test/lg-logic.js
+++ b/test/lg-logic.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 var expect = require('chai').expect;
 var lgLogic = require('../lib/_lg-logic.js');
@@ -9,21 +9,21 @@ describe('calcValue works as it should', () => {
   it('gutter, rounder, and unit ✅', () => {
     var testCase = lgLogic.calcValue('1/3', '30px', 100, 'vw');
 
-    var expectedResult = `calc(100vw * 1/3 - (30px - 30px * 1/3))`;
+    var expectedResult = 'calc(100vw * 1/3 - (30px - 30px * 1/3))';
 
     expect(testCase).to.equal(expectedResult);
   });
   it('no gutter ✅', () => {
     var testCase = lgLogic.calcValue('1/3', '0', 99.9);
 
-    var expectedResult = `calc(99.9% * 1/3)`;
+    var expectedResult = 'calc(99.9% * 1/3)';
 
     expect(testCase).to.equal(expectedResult);
   });
   it('no gutter ✅  when gutter is undefined', () => {
     var testCase = lgLogic.calcValue('1/3', undefined, 99.9);
 
-    var expectedResult = `calc(99.9% * 1/3)`;
+    var expectedResult = 'calc(99.9% * 1/3)';
 
     expect(testCase).to.equal(expectedResult);
   });

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -118,7 +118,7 @@ describe('lost-column', function() {
 
   it('Ignores bad unit', function() {
     check(
-      `a { lost-column: 2/6; lost-column-gutter: 10px; lost-unit: $; }`,
+      'a { lost-column: 2/6; lost-column-gutter: 10px; lost-unit: $; }',
 
       'a { width: calc(99.9% * 2/6 - (10px - 10px * 2/6)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 10px; clear: none; }\n' +
@@ -130,7 +130,7 @@ describe('lost-column', function() {
 
   it('Uses unit if one is passed', function() {
     check(
-      `a { lost-column: 2/6; lost-column-gutter: 10px; lost-unit: vw; }`,
+      'a { lost-column: 2/6; lost-column-gutter: 10px; lost-unit: vw; }',
 
       'a { width: calc(99.9vw * 2/6 - (10px - 10px * 2/6)); }\n' +
       'a:nth-child(1n) { float: left; margin-right: 10px; clear: none; }\n' +
@@ -169,22 +169,22 @@ describe('lost-column', function() {
   describe('supports RTL', () => {
     it('works with typical column', () => {
       check(
-        `@lost --beta-direction rtl;\n`+
-        `a { lost-column: 1/2; }`,
-        `a { width: calc(99.9% * 1/2 - (30px - 30px * 1/2)); }\n` +
-        `a:nth-child(1n) { float: right; margin-left: 30px; clear: none; }\n` +
-        `a:last-child { margin-left: 0; }\n` +
-        `a:nth-child(2n) { margin-left: 0; float: left; }\n` +
-        `a:nth-child(2n + 1) { clear: both; }`
+        '@lost --beta-direction rtl;\n'+
+        'a { lost-column: 1/2; }',
+        'a { width: calc(99.9% * 1/2 - (30px - 30px * 1/2)); }\n' +
+        'a:nth-child(1n) { float: right; margin-left: 30px; clear: none; }\n' +
+        'a:last-child { margin-left: 0; }\n' +
+        'a:nth-child(2n) { margin-left: 0; float: left; }\n' +
+        'a:nth-child(2n + 1) { clear: both; }'
       );
       check(
-        `@lost --beta-direction rtl;\n`+
-        `a { lost-column: 5/10; }`,
-        `a { width: calc(99.9% * 5/10 - (30px - 30px * 5/10)); }\n` +
-        `a:nth-child(1n) { float: right; margin-left: 30px; clear: none; }\n` +
-        `a:last-child { margin-left: 0; }\n` +
-        `a:nth-child(10n) { margin-left: 0; float: left; }\n` +
-        `a:nth-child(10n + 1) { clear: both; }`
+        '@lost --beta-direction rtl;\n'+
+        'a { lost-column: 5/10; }',
+        'a { width: calc(99.9% * 5/10 - (30px - 30px * 5/10)); }\n' +
+        'a:nth-child(1n) { float: right; margin-left: 30px; clear: none; }\n' +
+        'a:last-child { margin-left: 0; }\n' +
+        'a:nth-child(10n) { margin-left: 0; float: left; }\n' +
+        'a:nth-child(10n + 1) { clear: both; }'
       );
     });
   });

--- a/test/lost-waffle.js
+++ b/test/lost-waffle.js
@@ -143,14 +143,14 @@ describe('lost-waffle', function() {
   describe('supports RTL', () => {
     it('works with typical waffle', () => {
       check(
-        `@lost --beta-direction rtl;\n`+
-        `div { lost-waffle: 1/3; }`,
-        `div { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); height: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n` +
-        `div:nth-child(1n) { float: right; margin-left: 30px; margin-bottom: 30px; clear: none; }\n` +
-        `div:last-child { margin-left: 0; margin-bottom: 0; }\n` +
-        `div:nth-child(3n) { margin-left: 0; }\n` +
-        `div:nth-child(3n + 1) { clear: both; }\n` +
-        `div:nth-last-child(-n + 3) { margin-bottom: 0; }`
+        '@lost --beta-direction rtl;\n'+
+        'div { lost-waffle: 1/3; }',
+        'div { width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); height: calc(99.9% * 1/3 - (30px - 30px * 1/3)); }\n' +
+        'div:nth-child(1n) { float: right; margin-left: 30px; margin-bottom: 30px; clear: none; }\n' +
+        'div:last-child { margin-left: 0; margin-bottom: 0; }\n' +
+        'div:nth-child(3n) { margin-left: 0; }\n' +
+        'div:nth-child(3n + 1) { clear: both; }\n' +
+        'div:nth-last-child(-n + 3) { margin-bottom: 0; }'
       );
     });
   });


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**

Chore

**What is the current behavior (You can also link to an issue)**

Currently only `/lib` files are linted, and coverage isn't reported

**What is the new behavior this introduces (if any)**

Will lint all files (`/lib` and `/tests`), and upload coverage report to codecov.io

**Does this introduce any breaking changes?**

nope

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


**Other Comments**
