### PR TITLE
Limits flex-basis for IE10/11

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -154,6 +154,14 @@ module.exports = function lostColumnDecl(css, settings, result) {
           value: lgLogic.calcValue(lostColumn, lostColumnGutter, lostColumnRounder, unit)
         });
 
+        // IE 10-11 don't take into account box-sizing when calculating flex-basis, but
+        // adding an explicit max-width keeps them in line.
+        // https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
+        decl.cloneBefore({
+          prop: 'max-width',
+          value: lgLogic.calcValue(lostColumn, lostColumnGutter, lostColumnRounder, unit)
+        });
+
         if (gridDirection === 'rtl') {
           newBlock(
             decl,

--- a/test/lost-at-rule.js
+++ b/test/lost-at-rule.js
@@ -42,6 +42,7 @@ describe('lost-at-rule', function() {
       '  flex-grow: 0;\n' +
       '  flex-shrink: 0;\n' +
       '  flex-basis: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
+      '  max-width: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
       '  width: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
       '}\n' +
       'div:nth-child(1n) {\n' +

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -52,6 +52,7 @@ describe('lost-column', function() {
       'a { lost-column: 2/6 3 60px flex; }',
       'a { flex-grow: 0; flex-shrink: 0; ' +
       'flex-basis: calc(99.9% * 2/6 - (60px - 60px * 2/6)); ' +
+      'max-width: calc(99.9% * 2/6 - (60px - 60px * 2/6)); ' +
       'width: calc(99.9% * 2/6 - (60px - 60px * 2/6)); }\n' +
       'a:nth-child(1n) { margin-right: 60px; margin-left: 0; }\n' +
       'a:last-child { margin-right: 0; }\n' +


### PR DESCRIPTION
Fix for IE10/11 not taking `box-sizing` into account when using `flex-basis`, which causes problems when a column element is given `padding`. Adding a `max-width` of the same value keeps IE from growing the element too large.

https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box

**What kind of change is this? (Bug Fix, Feature...)**
Bug fix

**What is the current behavior (You can also link to an issue)**
In IE 10/11, flex columns that have `padding` and `box-sizing: border-box` end up overgrowing because those browsers do not take `box-sizing` into account when calculating `flex-basis`.

![before-max-width](https://user-images.githubusercontent.com/260837/26988200-66ccdd88-4d1c-11e7-8868-edacad388b7d.png)

**What is the new behavior this introduces (if any)**
By setting a `max-width`, IE10/11 adheres to `box-sizing`. This should not have an effect in other browsers that are already respecting `flex-basis`, `flex-grow: 0` and `flex-shrink: 0`.

![after-max-width](https://user-images.githubusercontent.com/260837/26988352-f8b6f63e-4d1c-11e7-96cc-958c116fd2d8.png)

**Does this introduce any breaking changes?**
If there is a column that has `flex-basis` but does not also specify `flex-grow: 0` then this may prevent that column from growing. Looking at the code it seems that lost does not do this, but if `flex-grow` is overridden in a user's stylesheet this could change things for them.

**Does the PR fulfill these requirements?**
- [X] Tests for the changes have been added
- [ ] Docs have been added or updated


**Other Comments**
