### PR TITLE
Remove deprecated moveTo method

### DIFF
--- a/lib/new-block.js
+++ b/lib/new-block.js
@@ -28,6 +28,6 @@ module.exports = function newBlock(decl, selector, props, values) {
       value: values[i].toString()
     });
 
-    rule.moveTo(block);
+    block.append(rule);
   });
 };


### PR DESCRIPTION
Fixes #372 - Replaced with append on block

**What kind of change is this? (Bug Fix, Feature...)**
Bug fix

**What is the current behavior (You can also link to an issue)**
#372 

**What is the new behavior this introduces (if any)**
Removes usage of deprecated Node#before method.

**Does this introduce any breaking changes?**
It shouldn't - change is internal.

**Does the PR fulfill these requirements?**
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated


**Other Comments**