### PR TITLE
Updates lost-column gutter validation.

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -64,7 +64,7 @@ module.exports = function lostColumnDecl(css, settings, result) {
         lostColumnCycle = declArr[0].split('/')[1];
       }
 
-      if (declArr[2] !== undefined && declArr[2].search(/^\d/) !== -1) {
+      if (declArr[2] !== undefined && declArr[2].search(/^[\.\d]/) !== -1) {
         lostColumnGutter = declArr[2];
       }
 

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -47,6 +47,30 @@ describe('lost-column', function() {
     );
   });
 
+  it('supports gutter with decimal value', function() {
+    check(
+      'a { lost-column: 2/5 0 0.7em; }',
+
+      'a { width: calc(99.9% * 2/5 - (0.7em - 0.7em * 2/5)); }\n' +
+      'a:nth-child(1n) { float: left; margin-right: 0.7em; clear: none; }\n' +
+      'a:last-child { margin-right: 0; }\n' +
+      'a:nth-child(0n) { margin-right: 0; float: right; }\n' +
+      'a:nth-child(0n + 1) { clear: both; }'
+    );
+  });
+
+  it('supports gutter with decimal value (no leading zero)', function() {
+    check(
+      'a { lost-column: 2/5 0 .5em; }',
+
+      'a { width: calc(99.9% * 2/5 - (.5em - .5em * 2/5)); }\n' +
+      'a:nth-child(1n) { float: left; margin-right: .5em; clear: none; }\n' +
+      'a:last-child { margin-right: 0; }\n' +
+      'a:nth-child(0n) { margin-right: 0; float: right; }\n' +
+      'a:nth-child(0n + 1) { clear: both; }'
+    );
+  });
+
   it('supports flexbox', function() {
     check(
       'a { lost-column: 2/6 3 60px flex; }',


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Bug Fix - Solves #367 

**What is the current behavior (You can also link to an issue)**
lost-column gutter reverts to default value if gutter value begins with a decimal point.

**What is the new behavior this introduces (if any)**
lost-column gutter allows value to begin with a decimal point.

**Does this introduce any breaking changes?**
Not as far as I can tell.

**Does the PR fulfill these requirements?**
- [ ✔️] Tests for the changes have been added
- [ ] Docs have been added or updated


**Other Comments**