### PR TITLE
Fixes issue where long-form flex isn't being set correctly 

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -80,7 +80,7 @@ module.exports = function lostColumnDecl(css, settings, result) {
 
       decl.parent.nodes.forEach(function lostColumnFlexboxFunction(declaration) {
         if (declaration.prop === 'lost-column-flexbox') {
-          if (declaration.prop === 'flex') {
+          if (declaration.value === 'flex') {
             lostColumnFlexbox = 'flex';
           }
 

--- a/lib/lost-row.js
+++ b/lib/lost-row.js
@@ -46,7 +46,7 @@ module.exports = function lostRowDecl(css, settings, result) {
 
       decl.parent.nodes.forEach(function lostRowFlexboxFunction(declaration) {
         if (declaration.prop === 'lost-row-flexbox') {
-          if (declaration.prop === 'flex') {
+          if (declaration.value === 'flex') {
             lostRowFlexbox = 'flex';
           }
 

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -12,7 +12,7 @@ describe('lost-column', function() {
         'max-width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); width:calc(99.9% * 1/3 - (30px - 30px * 1/3)); }' +
         'a:nth-child(1n) { margin-right: 30px; margin-left: 0; } a:last-child{ margin-right: 0; }' +
         'a:nth-child(3n) { margin-right: 0; margin-left: auto; }'
-      )
+      );
     });
   });
 

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -3,6 +3,20 @@
 var check = require('./check');
 
 describe('lost-column', function() {
+
+  describe('flexbox support', function() {
+    it('supports being set in long form', function() {
+      check(
+        'a { lost-column: 1/3; lost-column-flexbox: flex; }',
+        'a { flex-grow: 0; flex-shrink: 0; flex-basis: calc(99.9% * 1/3 - (30px - 30px * 1/3));' +
+        'max-width: calc(99.9% * 1/3 - (30px - 30px * 1/3)); width:calc(99.9% * 1/3 - (30px - 30px * 1/3)); }' +
+        'a:nth-child(1n) { margin-right: 30px; margin-left: 0; } a:last-child{ margin-right: 0; }' +
+        'a:nth-child(3n) { margin-right: 0; margin-left: auto; }'
+      )
+    });
+  });
+
+
   it('provides 3 column layout', function() {
     check(
       'a { lost-column: 1/3; }',

--- a/test/lost-row.js
+++ b/test/lost-row.js
@@ -3,6 +3,16 @@
 var check = require('./check');
 
 describe('lost-row', function() {
+
+  describe('Flexbox modifiers', function () {
+    it('supports flex in long-form', function() {
+      check(
+        'a { lost-row: 1/3; lost-row-flexbox: flex; }',
+        'a { width:100%; flex:0 0 auto; height:calc(99.9% * 1/3 - (30px - 30px * 1/3)); ' +
+        'margin-bottom: 30px; } a:last-child{ margin-bottom:0; }'
+      );
+    });
+  });
   it('provides 3 row layout', function() {
     check(
       'a { lost-row: 1/3; }',

--- a/test/lost-row.js
+++ b/test/lost-row.js
@@ -5,6 +5,24 @@ var check = require('./check');
 describe('lost-row', function() {
 
   describe('Flexbox modifiers', function () {
+    it('supports no-flex', function() {
+      check(
+        'a { lost-row: 1/3 no-flex; }',
+        'a { width: 100%; height: calc(99.9% * 1/3 - (30px - 30px * 1/3));' +
+        ' margin-bottom: 30px; }' +
+        'a:last-child { margin-bottom: 0; }'
+      );
+    });
+
+    it('supports no-flex in long-form', function() {
+      check(
+        'a { lost-row: 1/3; lost-row-flexbox: no-flex; }',
+        'a { width: 100%; height: calc(99.9% * 1/3 - (30px - 30px * 1/3));' +
+        ' margin-bottom: 30px; }' +
+        'a:last-child { margin-bottom: 0; }'
+      );
+    });
+
     it('supports flex in long-form', function() {
       check(
         'a { lost-row: 1/3; lost-row-flexbox: flex; }',
@@ -13,6 +31,8 @@ describe('lost-row', function() {
       );
     });
   });
+
+
   it('provides 3 row layout', function() {
     check(
       'a { lost-row: 1/3; }',
@@ -76,6 +96,7 @@ describe('lost-row', function() {
       ' margin-bottom: 0; }'
     );
   });
+
   describe('allows for customizable rounders', function() {
     it('100%', function() {
       check(


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Bugfix

**What is the current behavior (You can also link to an issue)**
Presently `lostRowFlexbox` is set to `lost-row-flexbox` (the property), not `flex` or `no-flex` (the value)
The same is also true for `lost-column-flexbox`.

**What is the new behavior this introduces (if any)**
It's fixed. All good. Nothing to see here. 😳 

**Does this introduce any breaking changes?**
Golly, I hope not.

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [N/A] Docs have been added or updated


**Other Comments**
So there are various things that I'm finding that are broken while adding tests. (YAY!) ...but does that mean that maybe these things don't need to be there? Long-term question...