### PR TITLE
example using postcss-js

### DIFF
--- a/lib/lost-center.js
+++ b/lib/lost-center.js
@@ -1,6 +1,49 @@
-var newBlock = require('./new-block.js');
+var assign = require('object-assign');
+
+var replace = require('./replace.js');
 
 var lgLogic = require('./_lg-logic');
+
+function lostCenter(flex, maxWidth, padding) {
+  var result = {};
+  
+  if (flex) {
+    assign(result, {
+      display: 'flex',
+      flexFlow: 'row wrap',
+    });
+  } else {
+    assign(result, {
+      ':after': {
+        content: '\'\'',
+        display: 'table',
+        clear: 'both'
+      }
+    });
+    
+    assign(result, {
+      ':before': {
+        content: '\'\'',
+        display: 'table'
+      }
+    });
+  }
+  
+  assign(result, {
+    maxWidth: maxWidth,
+    marginLeft: 'auto',
+    marginRight: 'auto'
+  });
+  
+  if (padding !== undefined) {
+    assign(result, {
+      paddingLeft: padding,
+      paddingRight: padding
+    });
+  }
+  
+  return result;
+}
 
 module.exports = function lostCenterDecl(css, settings, result) {
   css.walkDecls('lost-center', function lostCenterFunction(decl) {
@@ -54,59 +97,6 @@ module.exports = function lostCenterDecl(css, settings, result) {
       lostCenterMaxWidth = declArr[0];
     }
 
-    if (lostCenterFlexbox === 'no-flex') {
-      newBlock(
-        decl,
-        ':after',
-        ['content', 'display', 'clear'],
-        ['\'\'', 'table', 'both']
-      );
-
-      newBlock(
-        decl,
-        ':before',
-        ['content', 'display'],
-        ['\'\'', 'table']
-      );
-    } else {
-      decl.cloneBefore({
-        prop: 'display',
-        value: 'flex'
-      });
-
-      decl.cloneBefore({
-        prop: 'flex-flow',
-        value: 'row wrap'
-      });
-    }
-
-    decl.cloneBefore({
-      prop: 'max-width',
-      value: lostCenterMaxWidth
-    });
-
-    decl.cloneBefore({
-      prop: 'margin-left',
-      value: 'auto'
-    });
-
-    decl.cloneBefore({
-      prop: 'margin-right',
-      value: 'auto'
-    });
-
-    if (lostCenterPadding !== undefined) {
-      decl.cloneBefore({
-        prop: 'padding-left',
-        value: lostCenterPadding
-      });
-
-      decl.cloneBefore({
-        prop: 'padding-right',
-        value: lostCenterPadding
-      });
-    }
-
-    decl.remove();
+    replace(decl, lostCenter(lostCenterFlexbox === 'flex', lostCenterMaxWidth, lostCenterPadding));
   });
 };

--- a/lib/replace.js
+++ b/lib/replace.js
@@ -1,0 +1,56 @@
+var parse = require('postcss-js/parser');
+
+function newBlock(decl, selector) {
+  var completeSelector;
+  var block;
+
+  function appendToSelectors(_thisSelector, selectorToAppend) {
+    var appendedSelectors = [];
+
+    _thisSelector.split(',').forEach(function appendSelectorsFunction(item) {
+      appendedSelectors.push(item + selectorToAppend);
+    });
+
+    return appendedSelectors.join(',');
+  }
+
+  completeSelector = appendToSelectors(decl.parent.selector, selector);
+
+  block = decl.parent.cloneAfter({
+    selector: completeSelector
+  });
+
+  block.walkDecls(function removeDeclarationFunction(declaration) {
+    declaration.remove();
+  });
+
+  return block;
+}
+
+function appendCss(decl, block) {
+  decl.nodes.forEach(node => block.append({
+    prop: node.prop,
+    value: node.value
+  }));
+}
+
+function applyCss(decl, block) {
+  block.nodes.forEach(node => {
+    if (node.type === 'rule') {
+      appendCss(node, newBlock(decl, node.selector));
+    } else {
+      decl.cloneBefore({
+        prop: node.prop,
+        value: node.value
+      });
+    }
+  });
+}
+
+module.exports = function replace(decl, css) {
+  var root = parse(css);
+  
+  applyCss(decl, root);
+  
+  decl.remove();  
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "object-assign": "^4.1.0",
-    "postcss": "^6.0.6"
+    "postcss": "^6.0.6",
+    "postcss-js": "^1.0.0"
   },
   "keywords": [
     "grid",


### PR DESCRIPTION
- generate css for lost with javascript objects
- expose the functions that generate the css objects
- use postcss-js to generate the declarations to be applied by postcss

ref #396  