### PR TITLE
Add parameter no-height to lost-waffle

### DIFF
--- a/lib/lost-waffle.js
+++ b/lib/lost-waffle.js
@@ -8,7 +8,7 @@ module.exports = function lostWaffleDecl(css, settings) {
     var gridDirection = settings.direction;
     var lostWaffle;
     var floatRight;
-    var widthOnly;
+    var noHeight;
     var lostWaffleCycle;
     var unit = settings.gridUnit;
     var lostWaffleRounder = settings.rounder;
@@ -18,7 +18,7 @@ module.exports = function lostWaffleDecl(css, settings) {
 
     function cloneAllBefore(props) {
       Object.keys(props).forEach(function traverseProps(prop) {
-        if (prop === 'height' && widthOnly) return;
+        if (prop === 'height' && noHeight) return;
         decl.cloneBefore({
           prop: prop,
           value: props[prop]
@@ -59,8 +59,8 @@ module.exports = function lostWaffleDecl(css, settings) {
       floatRight = true;
     }
 
-    if (declArr.indexOf('width-only') !== -1) {
-      widthOnly = true;
+    if (declArr.indexOf('no-height') !== -1) {
+      noHeight = true;
     }
 
     decl.parent.nodes.forEach(function lostWaffleRounderFunction(declaration) {

--- a/lib/lost-waffle.js
+++ b/lib/lost-waffle.js
@@ -8,6 +8,7 @@ module.exports = function lostWaffleDecl(css, settings) {
     var gridDirection = settings.direction;
     var lostWaffle;
     var floatRight;
+    var widthOnly;
     var lostWaffleCycle;
     var unit = settings.gridUnit;
     var lostWaffleRounder = settings.rounder;
@@ -17,6 +18,7 @@ module.exports = function lostWaffleDecl(css, settings) {
 
     function cloneAllBefore(props) {
       Object.keys(props).forEach(function traverseProps(prop) {
+        if (prop === 'height' && widthOnly) return;
         decl.cloneBefore({
           prop: prop,
           value: props[prop]
@@ -55,6 +57,10 @@ module.exports = function lostWaffleDecl(css, settings) {
 
     if (declArr.indexOf('float-right') !== -1) {
       floatRight = true;
+    }
+
+    if (declArr.indexOf('width-only') !== -1) {
+      widthOnly = true;
     }
 
     decl.parent.nodes.forEach(function lostWaffleRounderFunction(declaration) {


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Feature

**What is the current behavior (You can also link to an issue)**
See #410 and #183 

**What is the new behavior this introduces (if any)**
New parameter to skip completely the height calculation in lost-waffle.
Ex:
```
div {
  lost-waffle: 1/3 no-height;
}
```
which will print:
```
div {
  width: calc(99.99999% * 1/3 - (20px - 20px * 1/3));
}
```

**Does this introduce any breaking changes?**
It's extremely simple, it shouldn't break anything.

**Does the PR fulfill these requirements?**
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

**Other Comments**
It's my first PR, I hope I'm doing it right...