### PR TITLE
Adds a deprecation warning for Node 4

### DIFF
--- a/lib/_check-node-version.js
+++ b/lib/_check-node-version.js
@@ -1,0 +1,17 @@
+var warning = 'LostGrid is dropping support for Node version v4 after version 9.\n If you need to retain your use of Node v4 it\'s recommended you don\'t\n update without testing it first. Submit an issue if you have questions. \n\n lostgrid.org';
+
+module.exports = function checkNodeVersion(nodeVersion) {
+  var returnOutput = {
+    warn: false,
+    warning: warning
+  };
+
+  if (nodeVersion) {
+    nodeVersion = nodeVersion.split('.')[0];
+    if (nodeVersion < 5) {
+      returnOutput.warn = true;
+    }
+
+  }
+  return returnOutput;
+};

--- a/lost.js
+++ b/lost.js
@@ -17,6 +17,11 @@ var lostMasonryColumn = require('./lib/lost-masonry-column');
 var lgGutter = require('./lib/lg-gutter');
 var lostVars = require('./lib/lost-vars');
 
+var checkNodeVersion = require('./lib/_check-node-version');
+
+// Get the version of Node
+var nodeVersion = process.env.npm_config_node_version;
+
 // Lost At Rules and Declarations
 var libs = [
   lostAtRule,
@@ -47,6 +52,11 @@ var defaultSettings = {
 
 module.exports = postcss.plugin('lost', function lost(settings) {
   var theseSettings = assign({}, defaultSettings, settings || {});
+
+  if (checkNodeVersion(nodeVersion).warn === true) {
+    //eslint-disable-next-line
+    console.log(checkNodeVersion(nodeVersion).warning);
+  }
 
   return function executeLostGrid(css, result) {
     libs.forEach(function executeEachLostRule(lib) {

--- a/test/node-version-check.js
+++ b/test/node-version-check.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var expect = require('chai').expect;
+var checkNodeVersion = require('../lib/_check-node-version');
+var nodeVersion = process.env.npm_config_node_version;
+
+describe('Logs Node warning if node version is 4', function() {
+  describe('Operates as it should with hard coded versions (for tests)', function() {
+    it('logs on 4', function() {
+      expect(checkNodeVersion('4').warn).to.not.equal(false);
+    });
+    it('doesn\'t log on new versions', function() {
+      expect(checkNodeVersion('6.9.1').warn).to.equal(false);
+      expect(checkNodeVersion('6.9.1').warn).to.not.equal(true);
+      expect(checkNodeVersion('7.0.0').warn).to.equal(false);
+      expect(checkNodeVersion('7.0.0').warn).to.not.equal(true);
+      expect(checkNodeVersion('8.9.4').warn).to.not.equal(true);
+    });
+  });
+  describe('Operates as it should real version', function() {
+    it('logs on 4', function() {
+      if (nodeVersion.split('.')[0] < 1) {
+        expect(checkNodeVersion(nodeVersion).warn).to.equal(true);
+        expect(checkNodeVersion(nodeVersion).warn).to.not.equal(false);
+      } else {
+        expect(checkNodeVersion(nodeVersion).warn).to.equal(false);
+        expect(checkNodeVersion(nodeVersion).warn).to.not.equal(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Patch for Node warning since Node 4 is deprecated

**What is the current behavior (You can also link to an issue)**
No warning

**What is the new behavior this introduces (if any)**
Warning users

**Does this introduce any breaking changes?**
No

**Does the PR fulfill these requirements?**
- [x] Tests for the changes have been added
- [x] Docs have been added or updated
