### PR TITLE
fix(plugin): fix options assignment

### DIFF
--- a/lost.js
+++ b/lost.js
@@ -47,7 +47,7 @@ module.exports = (settings = {}) => {
   return {
     postcssPlugin: 'lost',
     prepare() {
-      let runSettings = assign({}, defaultSettings, settings | {});
+      let runSettings = assign({}, defaultSettings, settings || {});
       return {
         AtRule(atRule) {
           lostAtRule(atRule, runSettings);

--- a/test/lost-plugin-options.js
+++ b/test/lost-plugin-options.js
@@ -39,6 +39,6 @@ describe('plugin-options', () => {
       })
     ])
       .process(input);
-      expect(output).to.equal(result.css);
+      expect(result.css).to.equal(output);
   });
 });

--- a/test/lost-plugin-options.js
+++ b/test/lost-plugin-options.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const postcss = require('postcss');
+const lost = require('../lost');
+const expect = require('chai').expect;
+
+describe('plugin-options', () => {
+  it('set options with plugin options', async () => {
+    const input = `
+    div {
+      lost-column: 1/2;
+    }
+    `;
+    const output = `
+    div {
+      flex-grow: 0;
+      flex-shrink: 0;
+      flex-basis: calc(99.9% * 1/2 - (15px - 15px * 1/2));
+      max-width: calc(99.9% * 1/2 - (15px - 15px * 1/2));
+      width: calc(99.9% * 1/2 - (15px - 15px * 1/2));
+    }
+    div:nth-child(1n) {
+      margin-right: 15px;
+      margin-left: 0;
+    }
+    div:last-child {
+      margin-right: 0;
+    }
+    div:nth-child(2n) {
+      margin-right: 0;
+      margin-left: auto;
+    }
+    `;
+    const result = await postcss([
+      lost({
+        gutter: '15px',
+        flexbox: 'flex',
+        cycle: 'auto'
+      })
+    ])
+      .process(input);
+      expect(output).to.equal(result.css);
+  });
+});


### PR DESCRIPTION
Hello @peterramsing,

still have a problem applying the user setting via an options object.

Here is a `Bitwise OR` used 😉 (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR)
```
 let runSettings = assign({}, defaultSettings, settings | {});
```

But we need a `Logical OR` (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR)

```
 let runSettings = assign({}, defaultSettings, settings || {});
```

Thanks!






