### PR TITLE
🔧 Fixes params splitting issues for other rules

### DIFF
--- a/lib/lost-at-rule.js
+++ b/lib/lost-at-rule.js
@@ -1,9 +1,9 @@
 module.exports = function lostAtRule(rule, settings) {
-  const breakoutParams = rule.params.split(' ');
-
   if (rule.name != 'lost') {
     return;
   }
+  const breakoutParams = rule.params.split(' ');
+
   if (breakoutParams[0] === 'gutter') {
     settings.gutter = breakoutParams[1];
   }


### PR DESCRIPTION
**What kind of change is this? (Bug Fix, Feature...)**
Fix

**What is the current behavior (You can also link to an issue)**
It's breaking params for the rules that are not related to lost, and I'm using a @font-face rule which doesn't having any rule params therefore resulting in a TypeError: Cannot read properties of undefined (reading 'split')

**What is the new behavior this introduces (if any)**
It now check the rule name first before breaking the params to avoid this error and successfully builds

**Does this introduce any breaking changes?**
No, they're not breaking changes

**Does the PR fulfill these requirements?**

- [x] Tests for the changes have been added
- [ ] Docs have been added or updated

**Other Comments**
